### PR TITLE
Speed up PR docker CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,10 @@ on:
     branches: ['main']
     types: [synchronize, opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,7 +19,7 @@ jobs:
         with:
           build: true
           npm-token: ${{ secrets.NPM_TOKEN }}
-          flavor: "localnet"
+          flavor: 'localnet'
 
   lint:
     runs-on: ubuntu-latest
@@ -24,7 +28,7 @@ jobs:
       - uses: ./.github/actions/build-install
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
-          flavor: "localnet"
+          flavor: 'localnet'
       - run: pnpm run lint
 
   test:
@@ -34,7 +38,7 @@ jobs:
       - uses: ./.github/actions/build-install
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
-          flavor: "localnet"
+          flavor: 'localnet'
       - run: pnpm test:ci
 
   docker:
@@ -47,6 +51,7 @@ jobs:
           project-name: 'atlasnet'
           app-name: 'explorer'
           gcp-auth-key: ${{ secrets.GCP_AUTH_KEY }}
+          platforms: 'linux/amd64'
           build-args: |
             FLAVOR=atlasnet
           extra-secrets: |


### PR DESCRIPTION
## Description

Cuts PR CI latency/cost for Docker validation.

- Adds PR workflow concurrency so superseded pushes cancel the older build-lint-test run.
- Makes the PR Docker smoke build target `linux/amd64` only.
- Leaves the main deploy workflow unchanged, so release images still build the existing multi-arch matrix.

## Why

The slow path is not lint/test/build. On PR #11:

- lint: ~41s
- test: ~77s
- Next build job: ~2m23s
- Docker job: ~25m21s

The Docker job was dominated by the emulated arm64 Next build on `ubuntu-latest`:

- amd64 Docker `pnpm build`: ~161s
- arm64 Docker `pnpm build` under QEMU: ~1435s

PR CI only needs to prove the image can build. Main deploy still builds and pushes the multi-arch release images.

## Result on this PR

- docker: 3m06s
- build: 2m36s
- lint: 43s
- test: 1m19s

The Docker log confirms the actual build command now uses `--platform linux/amd64`; the Docker `pnpm build` step took ~120s.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr.yml"); puts "yaml ok"'`
- `pnpm exec prettier --check .github/workflows/pr.yml`
- `actionlint .github/workflows/pr.yml`
- `git diff --check`
- PR CI: build/lint/test/docker/CodeQL all passed

