### PR TITLE
chore: refresh bundled C4 StarFrame IDLs

### DIFF
--- a/app/utils/starframe/idls/player-profile.json
+++ b/app/utils/starframe/idls/player-profile.json
@@ -2,7 +2,7 @@
   "kind": "programNode",
   "name": "playerProfileStarFrame",
   "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u",
-  "version": "0.45.0",
+  "version": "0.49.0",
   "accounts": [
     {
       "kind": "accountNode",

--- a/app/utils/starframe/idls/profile-faction.json
+++ b/app/utils/starframe/idls/profile-faction.json
@@ -2,7 +2,7 @@
   "kind": "programNode",
   "name": "profileFactionStarFrame",
   "publicKey": "C4FACQA1PpNRKrjQ2862ABNR42DTz7EzGj1uhTNFASwP",
-  "version": "0.45.0",
+  "version": "0.49.0",
   "accounts": [
     {
       "kind": "accountNode",

--- a/app/utils/starframe/idls/profile-subscription.json
+++ b/app/utils/starframe/idls/profile-subscription.json
@@ -2,7 +2,7 @@
   "kind": "programNode",
   "name": "profileSubscriptionStarFrame",
   "publicKey": "PSubAEkp16MhpP7AfB5kBbpWQ4cppUj9nxS5vUkHT13",
-  "version": "0.45.0",
+  "version": "0.49.0",
   "accounts": [
     {
       "kind": "accountNode",

--- a/app/utils/starframe/idls/sage.json
+++ b/app/utils/starframe/idls/sage.json
@@ -2,7 +2,7 @@
   "kind": "programNode",
   "name": "sageStarFrame",
   "publicKey": "C4SAgeKLgb3pTLWhVr6NRwWyYFuTR7ZeSXFrzoLwfMzF",
-  "version": "0.45.0",
+  "version": "0.49.0",
   "accounts": [
     {
       "kind": "accountNode",
@@ -92,6 +92,1309 @@
       "pda": {
         "kind": "pdaLinkNode",
         "name": "cargoDefinitionsCache"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "atlasRewardConfig",
+      "docs": [
+        "One immutable, fully authored reward configuration version."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "85a80b4f536dfda2",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "enabled",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "configVersion",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "effectiveEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "createdAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "sourceFlags",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad1",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochLenSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "claimSettlementWindowSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasBankInactivityExpirySecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardLootReclaimSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionPoolLever",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "kingSystemCurve",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "numberTypeNode",
+                  "format": "u64",
+                  "endian": "le"
+                },
+                "count": {
+                  "kind": "fixedCountNode",
+                  "value": 10
+                }
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 7
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pveLpRateBps",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pvpMedallionRateBps",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "salvageEvRateBps",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "repairKitLpRate",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lossModelTargetBps",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u16",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 3
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "starbaseDestructionMedallions",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 7
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "activeMedallion",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "medallionRewardConfig"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "medallionBuybackCapPerEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardReserveLowBalanceThreshold",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "upgradeLpRateCount",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "salvageEntryCount",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad2",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 6
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "upgradeLpRates",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "upgradeLpRate"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "salvageEntries",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "salvageRewardEntry"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 64
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "atlasRewardConfig"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "atlasRewardRegistry",
+      "docs": [
+        "Per-game epoch clock and pointer to immutable reward-config versions."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "cab7316c23f11c1f",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "currentEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "currentEpochStartedAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "currentEpochEndsAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "initialEpochOffsetSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "activeConfigVersion",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pendingConfigVersion",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pendingEffectiveEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "latestConfigVersion",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "atlasRewardRegistry"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "atlasRewardTreasury",
+      "docs": [
+        "Game-level finite cargo reserve backing medallion and synthetic-salvage issuance."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "b6a423b05d60ead6",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserves",
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "cargoId"
+              },
+              "value": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "atlasRewardTreasury"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "kingSystemTracker",
+      "docs": [
+        "Canonical membership and current effective major-faction ownership for the 69 King systems."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "6a7f2a971f7df6fe",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "systemCount",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "systemIds",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "systemId"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 69
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "owners",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "minorFactionId"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 69
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "majorCounts",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 3
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "configuredAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "kingSystemTracker"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "loyaltyAtlasBank",
+      "docs": [
+        "Persistent accumulated ATLAS entitlement for one `(profile, faction)`.",
+        "",
+        "Expiry is inactivity-based: a new credit extends the whole accumulated balance. Configuring expiry to",
+        "`0` makes the bank non-expiring. This is bounded state (one account per profile/faction), supports",
+        "week/month batching, and avoids an unbounded list of daily claim tranches."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "efd62b6ccc390373",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "profile",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 6
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "claimableAtlas",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lifetimeLp",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u128",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lifetimeAtlas",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u128",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastCreditedAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "expiresAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "loyaltyAtlasBank"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "loyaltyContribution",
+      "docs": [
+        "One profile's LP in one faction epoch. LP never rolls forward."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "80c61e873a4394a2",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "settled",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "profile",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad1",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 6
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochIndex",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lp",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u128",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasEntitlement",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "settledAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 24
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "loyaltyContribution"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "loyaltyEpoch",
+      "docs": [
+        "One faction's daily LP total and reserved ATLAS pool."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "1150ee0bed05ab73",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "status",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "loyaltyEpochStatus"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "kingSystems",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "configVersion",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochIndex",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "startsAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "endsAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "settlementDeadline",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "totalLp",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u128",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "poolAtlas",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "unsettledAtlas",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "settledAtlas",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "loyaltyEpoch"
       },
       "discriminators": [
         {
@@ -312,6 +1615,14 @@
             "type": {
               "kind": "definedTypeLinkNode",
               "name": "characterAssetCounts"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pilotXpBudget",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "pilotXpBudget"
             }
           },
           {
@@ -641,6 +1952,85 @@
                 "kind": "numberTypeNode",
                 "format": "i64",
                 "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardStatus",
+            "docs": [
+              "Future-hash combat-reward commitment. Ordinary cargo-only Loot keeps status `NONE`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardLegCount",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardPad",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardConfigVersion",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardCommitSlot",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardCommittedAt",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardLegs",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "combatRewardLeg"
               },
               "count": {
                 "kind": "fixedCountNode",
@@ -1513,6 +2903,405 @@
     },
     {
       "kind": "accountNode",
+      "name": "fleetCrewBinding",
+      "docs": [
+        "Each fleet's per-fleet crew aggregate. **Presence = at least one crew onboarded.** The",
+        "gameplay folds read `summary` (the sum of ONLY this fleet's onboarded crew), maintained by",
+        "`LoadFleetCrewRoster`/`UnloadFleetCrewRoster`.",
+        "",
+        "Body = 1 (version) + 1 (bump) + 6 (reserved) + 32 (fleet) + 32 (owner) + 315 (summary)",
+        "+ 8 (last_action_epoch) = **395 B**, align 1. (The summary grew 274 → 314 with the",
+        "per-skill-XP accumulator block, → 315 with the `max_rarity` cache byte; `last_action_epoch`",
+        "is the binding-tail Cold Start marker. The header fields before the summary —",
+        "version/bump/_reserved/fleet/owner, 72 B — are unchanged, so the summary still begins at",
+        "account-offset `8 (disc) + 72 = 80`, exactly as before.)"
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "cb4095256fccb8b5",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Data version of this account."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "PDA bump (managed by the framework on create)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "docs": [
+              "Reserved (zero today) — forward-compat slack (no alignment under `packed`)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 6
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "fleet",
+            "docs": [
+              "The fleet this cache belongs to (integrity check vs. the PDA seed)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "ownerProfile",
+            "docs": [
+              "The owner profile — the **owner-lock**, captured when the first crew onboards; a gameplay",
+              "resolve re-checks this == the fleet's `owner_profile`."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "summary",
+            "docs": [
+              "The per-fleet crew aggregate — the sum of ONLY the crew onboarded to this fleet. Identical",
+              "O(1) cache shape as the whole-roster `RosterSummary`, so the existing folds read it",
+              "unchanged in spirit (they just point at this per-fleet summary instead of the roster's)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "rosterSummary"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastActionEpoch",
+            "docs": [
+              "The fleet's last-acted withdraw-epoch (PerkCtx activation §2.4 — the",
+              "`FirstActionPerEpoch` marker for Cold Start #7). The warp instruction computes",
+              "`epoch = now / withdraw_epoch_duration`, evaluates",
+              "`first_action_this_epoch = (epoch != last_action_epoch)`, and stamps the new epoch after",
+              "the warp resolves (riding the existing `Mut` binding the XP-pour already holds).",
+              "Crew-owned state: a flag-off path has no binding, so this is never read nor written there.",
+              "Zero-default ⇒ the first action of epoch 0 reads \"first\" once — harmless, and only",
+              "observable when a Cold Start entry is present. Tail-appended after `summary`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "fleetCrewBinding"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "questProcess",
+      "docs": [
+        "On-chain record of a crew quest being processed at a starbase.",
+        "",
+        "Field-for-field the `StarbaseUpgradeProcess` shape (upgrade_rs:8-34) minus the",
+        "upgrade-only `system` / `resource_id` / `quantity` fields and plus the crew payout",
+        "`reward_xp`. `KeyFor<Profile>` / `KeyFor<StarbasePlayer>` are the typed owner",
+        "keys; `num_crew` is the crew committed to the quest (the amount",
+        "`reconcile_crew_allocation` moves out of the present pool while busy)."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "cc50602ee9b3a12f",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "The data version of this account."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "profile",
+            "docs": [
+              "The `Profile` key (the quest owner)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "starbasePlayer",
+            "docs": [
+              "The owning `StarbasePlayer` (the live-crew-counter choke-point)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "starbaseSeqId",
+            "docs": [
+              "The starbase sequence id this quest is anchored to (staleness/refund check, exactly",
+              "as `StarbaseUpgradeProcess.is_stale`, upgrade_rs:33-38)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "numCrew",
+            "docs": [
+              "Number of crew committed to the quest."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardXp",
+            "docs": [
+              "XP amount poured into the reward roster's accumulator on completion (the crew payout).",
+              "Named `reward_xp` because it is credited as XP via `folds.xp.pour_xp` — it grinds the",
+              "crew toward the perk-point milestones, it is NOT a direct perk-point mint (PR #732",
+              "fourth review). Bounded by the existing `PERK_POINTS_MAX` ceiling as a defensive cap."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardPage",
+            "docs": [
+              "The roster page the reward MUST be credited to (PR #732 third review): pinned by the",
+              "owner at `StartQuest`, enforced at `CompleteQuest`. The permissionless cranker cannot",
+              "choose the distribution page (an empty/low-value page would burn the payout to dust),",
+              "nor omit the roster to destroy it. Reuses 2 bytes of the former `_pad: [u8; 5]`, so the",
+              "account size/layout is unchanged (every other field offset is identical)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad",
+            "docs": [
+              "Tail pad so `start_time` / `end_time` stay byte-flush under `#[repr(C, packed)]` and",
+              "the struct ends on a clean boundary (no semantic meaning)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 3
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "startTime",
+            "docs": [
+              "The quest start timestamp."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "endTime",
+            "docs": [
+              "The quest end timestamp (crew become free / payout claimable at/after this)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          }
+        ]
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "crewRoster",
+      "docs": [
+        "The bulk crew container for one `(Character, page_index)`: a `RosterSummary` cache",
+        "header + an append-only `List<CrewRecord>`.",
+        "",
+        "`#[unsized_type(program_account, seeds = CrewRosterSeeds)]` — same form as the",
+        "marketplace `Market` (marketplace/src/state_rs:384-398) and SAGE `Character`",
+        "(character_rs:17-29). `summary` is the sized packed header (315 B); `crew` is the",
+        "unsized tail."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "37c62b04691cf15a",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "summary",
+            "docs": [
+              "The cached O(1) aggregate (the resurrected `total_crew` lives in",
+              "`summary.normalized_crew_total`). Packed 315-byte header."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "rosterSummary"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "crew",
+            "docs": [
+              "The crew records on this page, byte-packed (`CrewRecord: Align1` ⇒ List-able)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "crewRecord"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "crewRoster"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
       "name": "currencyConfigCache",
       "data": {
         "kind": "structTypeNode",
@@ -1619,6 +3408,2712 @@
       "pda": {
         "kind": "pdaLinkNode",
         "name": "currencyConfigCache"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "encounterCommit",
+      "docs": [
+        "Per-character commit tracker for the two-phase encounter reveal (Option B — migration-safe; this",
+        "avoids touching the core `Fleet` account, which is a non-singleton `#[unsized_type]` with no spare",
+        "pad). Created once per character via `OpenEncounterTracking`; a scan that arms an encounter stamps",
+        "`commit_slot` + `region_id` + the triggering `fleet` here. The reveal reads it, draws the contents",
+        "from a *later* slot's hash, and clears it. One pending encounter per character at a time — a",
+        "subsequent scan overwrites the prior pending commit (reinforces the anti-multi-fleet design)."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "f16e321b932300da",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "character",
+            "docs": [
+              "The owning character (also the scoping seed)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "fleet",
+            "docs": [
+              "The fleet that armed the current pending commit (`None` when empty)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "commitSlot",
+            "docs": [
+              "The slot of the arming scan. The reveal must consume a slot hash strictly later than this."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "regionId",
+            "docs": [
+              "The region pinned at scan time (resolved from the fleet's location)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "regionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "status",
+            "docs": [
+              "`STATUS_EMPTY` (0) or `STATUS_PENDING` (1)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "location",
+            "docs": [
+              "The exact sector where the encounter armed (the scanning fleet's location). Copied onto the market",
+              "at reveal; trading requires a fleet idle AT this sector."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "i64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minorFaction",
+            "docs": [
+              "The minor faction PINNED at scan time — the `(region, faction)` pool the player committed to BEFORE",
+              "the reveal's future hash existed. Reveal requires the supplied pool's `minor_faction` to equal this,",
+              "so the faction can't be steered after the entropy is knowable. `Default` (0) when the commit is empty."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "docs": [
+              "Tail-append room for additive growth."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "encounterCommit"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "encounterPool",
+      "docs": [
+        "The dev-registered ENVELOPE for one `(region, minor_faction)` encounter pool.",
+        "",
+        "Long-lived; created/edited only by `MANAGE_NPC_ENCOUNTERS`-gated admin instructions and read-only",
+        "at encounter time. Modeled on [`ScanPattern`](crate::state::ScanPattern): a sized header + an",
+        "`#[unsized_start]` `List` tail (additive growth lives in the tail)."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "215ec061ef8ef371",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Layout version (mirrors `ScanPattern.version`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "docs": [
+              "Game scoping key."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "regionId",
+            "docs": [
+              "The zone this pool belongs to."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "regionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minorFaction",
+            "docs": [
+              "The minor-faction NPC this pool represents (off-chain lore name mapped by `MinorFactionId`)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "status",
+            "docs": [
+              "Reuses the `Draft`/`Active` gate idiom; only `Active` pools can spawn an encounter."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "scanPatternStatus"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "triggerWeight",
+            "docs": [
+              "Ultra-rare candidacy chance, as `trigger_weight / trigger_total` (kept well under ~1%).",
+              "Same fixed-point domain as the scan roll (`U16F16`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "triggerTotal",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "marketTtlSecs",
+            "docs": [
+              "Market lifetime once revealed, in seconds (decision #4 = 300). Applied as `now + ttl` at reveal."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasBurnBps",
+            "docs": [
+              "ATLAS-burn sink on the faucet leg, in basis points. `0` = off (default until econ enables)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "faucetEnabled",
+            "docs": [
+              "`0` = the faucet leg (NPC buys from the player) is disabled ⇒ the market is **sell-only**.",
+              "Default off until econ enables it per pool (decision 1-c)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rotationEnabled",
+            "docs": [
+              "`0` = no catalog rotation; non-zero = rotate the available offers each `rotation_period_secs`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rotationPeriodSecs",
+            "docs": [
+              "Rotation epoch length in seconds (anti-staleness); ignored when `rotation_enabled == 0`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "offers",
+            "docs": [
+              "The allowed item set (buy + sell offers, side per entry). A revealed market is a weighted subset."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "poolOfferEntry"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "encounterPool"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "encounterTreasury",
+      "docs": [
+        "The finite, pre-funded reserve + per-epoch ATLAS-out circuit-breaker for one `(region, faction)` pool.",
+        "",
+        "All economic value lives here (decisions #1/#3): the ATLAS `vault` pays sell-backs and receives",
+        "player buys; `reserves` is the finite cargo stock (no minting — Asks draw down, Bids credit back).",
+        "Kept separate from [`EncounterPool`] (config) so the value account is written on trades while the",
+        "envelope stays a rarely-written config account. Modeled on `LocalMarket`'s vault + `CargoPod`'s map."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "51a1c539e3a992c2",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "regionId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "regionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minorFaction",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "vault",
+            "docs": [
+              "ATLAS reserve: pays sell-backs (faucet leg), receives player buys. Same type as `LocalMarket.vault`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochStart",
+            "docs": [
+              "Circuit-breaker (decision #1), modeled on `CurrencyBalanceCache.circuit_breaker`: caps total ATLAS",
+              "emitted (faucet leg) per epoch, so concentrated/grinding draw cannot drain a restock in one block.",
+              "Reset when `now >= epoch_start + epoch_len_secs`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochLenSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasOutThisEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasOutCapPerEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserves",
+            "docs": [
+              "Finite, pre-stocked cargo reserve. Asks draw down from here; Bids (sell-back) credit back here.",
+              "No minting (decision #3). Same idiom as `CargoPod.amounts` / `CargoDefinitions.cargo_types`."
+            ],
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "cargoId"
+              },
+              "value": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "encounterTreasury"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "ephemeralMarket",
+      "docs": [
+        "The revealed, player-scoped, time-boxed NPC market (Phase 3). Created (player-funded) at reveal when",
+        "the rare candidacy hits; holds the concrete `LiveOffer`s + an `expires_at`. Trades settle DIRECTLY",
+        "against the `EncounterTreasury`, so this account itself holds NO funds (close is trivial — nothing to",
+        "sweep). One open market per character at a time (seeds = game + owner character); the prior one must",
+        "be reaped before a new reveal."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "bba828535a25d9c1",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "ownerCharacter",
+            "docs": [
+              "The only character that may trade here — the access binding (seed component)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "regionId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "regionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minorFaction",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pool",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "treasury",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "funder",
+            "docs": [
+              "Rent payer (the owner), refunded on close."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasBurnBps",
+            "docs": [
+              "ATLAS-burn on the faucet (sell-back) leg, basis points — copied from the pool at reveal so the",
+              "trade is self-contained (doesn't need the pool account)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "expiresAt",
+            "docs": [
+              "Market lifetime, unix seconds: set to `now + pool.market_ttl_secs` at reveal; fail-closed at trade."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "location",
+            "docs": [
+              "The exact sector the encounter spawned at (copied from the commit at reveal). Trading requires the",
+              "owner's fleet to be idle AT this sector; the map UI + nemesis read it to place the merchant marker."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "i64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "offers",
+            "docs": [
+              "The concrete offers drawn from the pool envelope at reveal; trading decrements `remaining_qty`."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "liveOffer"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "ephemeralMarket"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "factionAccount",
+      "docs": [
+        "The per-faction record in the dynamic registry (decision D1/D8). Sized, packed, 209 bytes.",
+        "",
+        "Modeled on `ProfileFactionAccount` (a sized",
+        "`ProgramAccount` embedding the [`Faction`] enum) + the [`EncounterPool`](crate::state::EncounterPool)",
+        "header (`(game, …, minor_faction)` scoping). Growth is by carving from `_reserved` (version-gated),",
+        "never by appending."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "5e915f21ab6fb807",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Layout/schema version (migration lever)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "docs": [
+              "Game scoping key."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionId",
+            "docs": [
+              "The dynamic faction id (reuses the `MinorFactionId` space; `0` = null, `1/2/3` = majors)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "alignment",
+            "docs": [
+              "Legacy alignment bridge: `Unaligned` for minors; `MUD/ONI/Ustur` for the 3 majors."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "faction",
+              "program": {
+                "kind": "programLinkNode",
+                "name": "profileFactionStarFrame"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "capabilityFlags",
+            "docs": [
+              "Capability bitset ([`FactionCapabilityFlags`])."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "status",
+            "docs": [
+              "Lifecycle status."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "factionStatus"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "authorityBump",
+            "docs": [
+              "Cached bump of the `FactionAuthority` PDA (the program-derived signer used in P2/P5)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "controller",
+            "docs": [
+              "Optional guild controller (P0: always `NONE`; the validated assignment lands in P1)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "maxAllies",
+            "docs": [
+              "Max simultaneous Allied edges (diplomacy cap, enforced in P3). Default 3."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "treasuryCount",
+            "docs": [
+              "Advisory count of this faction's treasuries (P2)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "homeRegion",
+            "docs": [
+              "Homeland region for safe-zones / spawn origin (`0` = none)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "regionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "nameHash",
+            "docs": [
+              "Content-addressed off-chain lore reference (SHA-256 of the canonical content file)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "contentUriHash",
+            "docs": [
+              "Off-chain manifest hash (cosmetics, blueprint catalog, dialogue)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "createdAt",
+            "docs": [
+              "Creation timestamp (unix seconds)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "operatorProfile",
+            "docs": [
+              "The faction's NPC fleet OPERATOR profile (the un-rentable `SagePlayerProfile` whose key flies this",
+              "faction's NPC fleets). `NONE` until an admin binds it via `SetFactionOperator`; `MintNpcFleet` requires",
+              "the minting operator to equal this exactly. (0-valued `NONE` = no operator = no NPC fleets.)"
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastCaptureAt",
+            "docs": [
+              "Unix ts of this faction's most recent dynamic starbase capture — the per-faction anti-blitz cursor",
+              "(`attack_starbase` STEP H refuses a new capture until `this + faction_capture_cooldown_secs`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "npcFleetCount",
+            "docs": [
+              "Live (concurrent) count of this faction's NPC fleets: bumped at `MintNpcFleet`, and decremented on every",
+              "fleet-teardown path (disband / forced-disband / admin-remove / destroyed-cleanup) when the caller",
+              "supplies the fleet's FLEET-kind `FactionOwnership` sidecar + this account. ⚠ BEST-EFFORT: the",
+              "PERMISSIONLESS destroyed-cleanup path may omit those optionals, leaving the slot occupied — so under",
+              "adversarial cleanup the cap degrades toward a lifetime mint cap (never WORSE than that). A fully",
+              "non-gameable concurrent cap would need an on-`Fleet` NPC marker (the `Fleet` account has no reserve for",
+              "one without a breaking layout change — deferred)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "maxNpcFleets",
+            "docs": [
+              "Hard cap on this faction's concurrent NPC fleets — the PRIMARY anti-flood brake (independent of ATLAS",
+              "cost). Enforced at `MintNpcFleet` against the live `npc_fleet_count`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "docs": [
+              "Additive growth space (carve from the front, version-gated; never append)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 14
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "factionAccount"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "factionConfig",
+      "docs": [
+        "Per-game reputation dials. Sized, packed, 48 bytes."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "340cfea68f357c37",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Schema/migration lever."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "decayPerDay",
+            "docs": [
+              "Passive decay toward 0 per day."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "dailyCap",
+            "docs": [
+              "Per-(profile,faction) daily burst ceiling on `|delta|`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standingBps",
+            "docs": [
+              "Ask-leg value→standing bps (Accrual A); `0` disables sell-order accrual."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "drHalfLife",
+            "docs": [
+              "`lifetime_earned` DR half-life."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "drScale",
+            "docs": [
+              "`lifetime_earned` divisor before the DR curve."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standingEpochCap",
+            "docs": [
+              "Per-faction per-epoch aggregate standing-emission cap."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standingEpochLenSecs",
+            "docs": [
+              "Epoch length (secs) for the per-faction breaker."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "dockMinBand",
+            "docs": [
+              "Gate (d) economic-dock minimum band index."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "territoryYieldPerTick",
+            "docs": [
+              "P5 territory payoff: ATLAS yield per hold-tick to the controlling faction's treasury (0 = disabled)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "territoryYieldTickSecs",
+            "docs": [
+              "P5 territory payoff: yield accrual cadence (secs); a claim credits the whole ticks elapsed."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad",
+            "docs": [
+              "Reserved (carve from the front)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 1
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "factionConfig"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "factionEconomicsConfig",
+      "docs": [
+        "Per-game NPC-economy tuning dials. Sized, packed, `Align1`, 72 bytes."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "ea6e42b0033088e3",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Schema/migration lever."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "docs": [
+              "Game scoping (also the sole seed)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "npcMintCostAtlas",
+            "docs": [
+              "ATLAS debited from the minting faction's treasury per `MintNpcFleet`. `0` = free (test only — set",
+              "`> 0` at activation so the treasury is load-bearing and \"defunded ⇒ quiet\" actually holds)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "npcRespawnCostAtlas",
+            "docs": [
+              "ATLAS debited per NPC fleet respawn (the churn brake; keep `> 0` at activation)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "captureCostAtlas",
+            "docs": [
+              "ATLAS debited from the captor faction's treasury per dynamic starbase capture (skin-in-the-game; a",
+              "defunded faction cannot pay ⇒ self-quieting). `0` = no capture cost."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionCaptureCooldownSecs",
+            "docs": [
+              "Per-faction anti-blitz capture cooldown (secs): `attack_starbase` STEP H refuses a new dynamic capture",
+              "until `FactionAccount.last_capture_at + this`. Lives here (8 B) — it does NOT fit the tracker reserve."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "docs": [
+              "Additive growth budget (carve from the front; never append)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 10
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "factionEconomicsConfig"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "factionEpochMeter",
+      "docs": [
+        "Per-`(game, faction_id)` aggregate standing-emission meter. Sized, packed, 56 bytes."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "5c67f8a530f65320",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Schema/migration lever."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "docs": [
+              "Reserved."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 4
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "docs": [
+              "Game scoping."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionId",
+            "docs": [
+              "The faction whose aggregate emission this meters."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "currentEpoch",
+            "docs": [
+              "Current epoch index (`now / epoch_len`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standingOutThisEpoch",
+            "docs": [
+              "Standing minted FOR this faction in the current epoch (across all players)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "factionEpochMeter"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "factionMarket",
+      "docs": [
+        "A persistent faction market at one starbase. 120 B sized header + `offers: List<LiveOffer>` tail."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "a1462e693939ee02",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionId",
+            "docs": [
+              "Owning faction; the `FactionTreasury` PDA is derived from this (2nd treasury seed)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "system",
+            "docs": [
+              "Anchored star system (2nd market seed). `KeyFor<Starbase>` does not exist → key on the system."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "starbaseSeqId",
+            "docs": [
+              "Pins a starbase incarnation within the system (3rd seed). Source is `StarSystem.seq_id`",
+              "(read `system.data()?.seq_id`); this is the market's own copy."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "status",
+            "docs": [
+              "Draft/Active lifecycle (REUSED `ScanPatternStatus`; `CheckedBitPattern`, not `Pod`)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "scanPatternStatus"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minStandingBuy",
+            "docs": [
+              "Access band to BUY (Ask leg): converted via `band_of(.0 as i32)`. `<= -1000` = open."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minStandingSell",
+            "docs": [
+              "Access band to SELL (faucet leg). `<= -1000` = open (so a Hostile player can still sell their way back)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "priceTierBps",
+            "docs": [
+              "Per-depletion-tier Ask price multiplier (bps). Index from reserve depletion (`depletion_tier`,",
+              "quartile bands); standing does NOT affect pricing (access-gating-only decision). `[u16;4]` (each",
+              "element align-1)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u16",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 4
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "authoredTargetQty",
+            "docs": [
+              "Per-offer restock target, committed at create; opportunistic restock tops `remaining_qty` toward it."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "restockPeriodSecs",
+            "docs": [
+              "In-trade restock time-gate (seconds); a restock runs at most once per period."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastRestockAt",
+            "docs": [
+              "Last successful restock (unix seconds)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasBurnBps",
+            "docs": [
+              "ATLAS-burn on the faucet (sell-back) leg, basis points."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standingBps",
+            "docs": [
+              "Graduated per-market accrual rate (overrides `FactionConfig.standing_bps`); `0` disables earning here."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "faucetEnabled",
+            "docs": [
+              "`0` = sell-only (faucet disabled)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad",
+            "docs": [
+              "Reserved (carve-from for additive growth, e.g. more price tiers)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 4
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "offers",
+            "docs": [
+              "Concrete Ask/Bid offers; `remaining_qty` topped toward `authored_target_qty` by the in-trade restock."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "liveOffer"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "factionMarket"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "factionOwnership",
+      "docs": [
+        "Dynamic-ownership sidecar for ONE asset. Sized `Pod` (the `CurrencyConfigCache` idiom), `#[repr(C,packed)]`,",
+        "`Align1`. `directive_block` is RESERVED for P5 (zero-written, read nowhere in P4)."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "50c73351876463e3",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Schema/migration lever (=0)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "This account's PDA bump."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "docs": [
+              "Game scoping (AccountValidate compares)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "assetKind",
+            "docs": [
+              "STARBASE=0 / FLEET=1 / REGION=2 (== the 2nd seed byte; MUST stay a seed forever — collision boundary)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "assetKey",
+            "docs": [
+              "Canonical 32-byte identity (== the 3rd seed)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "controllingFaction",
+            "docs": [
+              "Dynamic controller; 0 = fall back to the legacy enum owner."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "previousController",
+            "docs": [
+              "The controller BEFORE the most recent capture (0 = none) — grants the displaced owner a",
+              "contested-window re-capture bypass (anti capture-and-camp)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "capturedAt",
+            "docs": [
+              "Unix ts of the last (re)capture / pre-seed."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "contestedUntil",
+            "docs": [
+              "No re-flip until `now >= this` (0 = immediately capturable)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "capturedSeqId",
+            "docs": [
+              "Generation witness (== `StarSystem.seq_id` at capture) — NOT a seed (seq_id mutates on capture/removal).",
+              "Checked + re-stamped at the boundary. 0 for Fleet/Region."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "directiveBlock",
+            "docs": [
+              "RESERVED for P5 (asset_kind=Fleet directive payload). Written ALL-ZERO in P4; read NOWHERE."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 28
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastYieldTickTs",
+            "docs": [
+              "P5 territory payoff: per-asset yield idempotency cursor (STARBASE sidecars only; whole-tick advance).",
+              "0 = never claimed. NEVER overlaps `directive_block` (the FLEET-sidecar reuse of those bytes)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "docs": [
+              "Additive growth budget — carve typed (Pod, 0-valid) fields from the FRONT; NEVER append. `asset_kind`",
+              "MUST remain a seed component forever."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 6
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "factionOwnership"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "factionRelationTracker",
+      "docs": [
+        "The diplomacy relation matrix + combat-gating config for one game.",
+        "",
+        "Sized 66-B header + a sparse `Map<FactionPair, RelationEntry>` tail. `combat_gating_enabled == 0`",
+        "(default) reproduces today's behavior. Future fields carve from `_reserved` (BEFORE `#[unsized_start]`)."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "07e91c0066d082fc",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Layout/schema version (migration lever)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "combatGatingEnabled",
+            "docs": [
+              "`0` = OFF (today's same-faction-only combat), `1` = relation-gated combat ON."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "territoryAccessEnabled",
+            "docs": [
+              "`0` = OFF (own-faction docking only), `1` = relation/standing dock admission ON (P3 dock compose)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "docs": [
+              "Game scoping key (also the sole seed)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "crossFactionEconomicsEnabled",
+            "docs": [
+              "P3.5 reserved: cross-faction warp economics master switch (OFF; warp is structurally foreclosed today)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "docs": [
+              "Reserved."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "alliedTollBps",
+            "docs": [
+              "P3.5 reserved: allied cross-faction warp toll (bps)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "neutralTollBps",
+            "docs": [
+              "P3.5 reserved: neutral cross-faction warp toll (bps)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "ceasefireMinDurationSecs",
+            "docs": [
+              "Minimum ceasefire duration (secs) `SetFactionRelation` will accept."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reCeasefireCooldownSecs",
+            "docs": [
+              "Cooldown (secs) after a ceasefire ends before the same pair may re-enter one."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "dynamicCaptureEnabled",
+            "docs": [
+              "P4 territory: dynamic-capture regime master switch. `0` = OFF (today's legacy starbase capture);",
+              "`1` = ON (`attack_starbase` requires the `FactionOwnership` sidecar + resolves the dynamic controller)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "contestedWindowSecs",
+            "docs": [
+              "P4 territory: base contested-window (secs) a capture stamps onto `FactionOwnership.contested_until`",
+              "(clamped UP to `MIN_CONTESTED_WINDOW_SECS`). Set via `SetFactionRelationConfig`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "nemesisActive",
+            "docs": [
+              "P5b antagonist master switch. `0` = OFF (no NPC fleet minting/funding, dead COMBATANT capture path);",
+              "`1` = ON. The activation DOUBLE-GATE is `dynamic_capture_enabled == 1 && nemesis_active == 1`, both read",
+              "off this tracker (which both `attack_*` ix already load). Carved here — NOT on `Game.combat`, which has",
+              "no pad (any field there shifts `crew_config` + every `Game` decoder). Default 0 = flag-OFF byte-identical."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "docs": [
+              "Additive growth space (carve from the front, version-gated). ⚠ Only 2 B remain — single-byte flags only;",
+              "route any future multi-byte tracker dial to `FactionEconomicsConfig`."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "relations",
+            "docs": [
+              "Sparse relation matrix; Neutral pairs are absent."
+            ],
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "factionPair"
+              },
+              "value": {
+                "kind": "definedTypeLinkNode",
+                "name": "relationEntry"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "factionRelationTracker"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "factionStanding",
+      "docs": [
+        "Per-`(game, profile, faction_id)` reputation standing (P1). Sized, packed, 132 bytes."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "514fa2e1b7a57785",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Schema/migration lever."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "PDA bump (cached; NEVER trusted — re-derived at every site)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "flags",
+            "docs": [
+              "bit0 = storyline-active (see `storyline_expiry_ts`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bandFloor",
+            "docs": [
+              "Highest band INDEX ever reached (0..5; decay floor, capped at Honored)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standing",
+            "docs": [
+              "Signed standing, clamped `[-1000, +1000]`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lifetimeEarned",
+            "docs": [
+              "Σ POSITIVE accruals ever; write-once-increasing (the DR anchor)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "accrualToday",
+            "docs": [
+              "Running `|delta|` (both signs) in the current daily window."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "dayAnchorTs",
+            "docs": [
+              "Start of the current daily window."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastUpdateTs",
+            "docs": [
+              "Drives lazy decay (realize-on-touch)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "docs": [
+              "Game scoping."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "profile",
+            "docs": [
+              "Identity-bind #1."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionId",
+            "docs": [
+              "Identity-bind #2 + 3rd seed."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "docs": [
+              "RESERVED (packed = align 1; NOT alignment padding)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 6
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bandFloorReachedTs",
+            "docs": [
+              "When `band_floor` last ratcheted up (anti spike-and-dump for the top gates)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "storylineExpiryTs",
+            "docs": [
+              "Freeze self-expires at this ts (`0` = no freeze)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "docs": [
+              "Additive growth (carve from the front; never append)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 8
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "factionStanding"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "factionTreasury",
+      "docs": [
+        "Per-faction value account (one per faction). 76 B sized header + `reserves` + `floors` Map tails."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "41752c05814f5b31",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionId",
+            "docs": [
+              "The owning faction (also the 2nd seed). One treasury per faction."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "vault",
+            "docs": [
+              "ATLAS reserve: receives player buys (Ask), pays sell-backs (faucet). Same type as `LocalMarket.vault`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochStart",
+            "docs": [
+              "Per-epoch ATLAS-out circuit-breaker (verbatim `EncounterTreasury` idiom): caps total faucet ATLAS",
+              "emitted per epoch. Reset when `now >= epoch_start + epoch_len_secs`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochLenSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasOutThisEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasOutCapPerEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserves",
+            "docs": [
+              "Finite, pre-stocked cargo reserve (no minting). Asks draw down; Bids credit back. Byte-identical",
+              "codec to `EncounterTreasury.reserves`."
+            ],
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "cargoId"
+              },
+              "value": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "floors",
+            "docs": [
+              "Per-cargo strategic-reserve FLOOR (anti-drain): an Ask caps fill so `reserves[cargo] >= floors[cargo]`.",
+              "Lives on the treasury (NOT per-market) so it composes across a faction's N markets. Absent = 0."
+            ],
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "cargoId"
+              },
+              "value": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "factionTreasury"
       },
       "discriminators": [
         {
@@ -1779,6 +6274,14 @@
               "kind": "definedTypeLinkNode",
               "name": "researchTreeDefinitions"
             }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stimulantDefinitions",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "stimulantDefinitions"
+            }
           }
         ]
       },
@@ -1865,7 +6368,7 @@
             "name": "subProfile",
             "docs": [
               "The fleet's sub-authority.",
-              "If [`Some`] will have the exclusive ability to interact with this fleet."
+              "If `Some` will have the exclusive ability to interact with this fleet."
             ],
             "type": {
               "kind": "publicKeyTypeNode"
@@ -1894,6 +6397,18 @@
                 "kind": "programLinkNode",
                 "name": "profileFactionStarFrame"
               }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "npcFactionId",
+            "docs": [
+              "Structural NPC classification. `0` is a player fleet; a nonzero id is the authored NPC faction.",
+              "Reward branching reads this field instead of trusting an omittable ownership sidecar."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
             }
           },
           {
@@ -2192,6 +6707,32 @@
             "type": {
               "kind": "definedTypeLinkNode",
               "name": "cargoPod"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "activeStimulants",
+            "docs": [
+              "Active combat stimulants applied to the fleet, keyed by affected combat stat."
+            ],
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "combatStatField"
+              },
+              "value": {
+                "kind": "definedTypeLinkNode",
+                "name": "activeStimulant"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
             }
           },
           {
@@ -2531,6 +7072,918 @@
       "pda": {
         "kind": "pdaLinkNode",
         "name": "localMarket"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "missionProcess",
+      "docs": [
+        "On-chain record of a mission being processed at a starbase. **188 B, `#[repr(C, packed)]`, align 1.**",
+        "Field order: status/identity → counters → stake → RNG commit → reward routing → timing → outcome →",
+        "the 4 appended Phase-2 faction-stance pins (stance_side/base_faction/sector_incumbent/pinned_outlaw).",
+        "Every multi-byte field byte-flush (the crew-record idiom); offsets are doc 10 §1.2 + doc 180 §10's grow."
+      ],
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "512653ba6b23a189",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "off 0 — layout/schema version (mirrors `QuestProcess.version`). v0 = this layout."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "off 1 — stake-vault PDA bump (`(b\"MissionVault\", mission_key)`); stored to avoid re-derivation."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "status",
+            "docs": [
+              "off 2 — `MissionStatus` (in-flight assertion + decoder/event convenience)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "outcomePad",
+            "docs": [
+              "off 3 — reserved (zero)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "profile",
+            "docs": [
+              "off 4 — the mission owner (reward + injury target). Stamped from the VALIDATED starbase-player."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "starbasePlayer",
+            "docs": [
+              "off 36 — the live `busy_crew` counter the crew were reserved against (cross-checked, §below)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "starbaseSeqId",
+            "docs": [
+              "off 68 — staleness/refund check, verbatim `QuestProcess.starbase_seq_id`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "missionTemplateId",
+            "docs": [
+              "off 76 — the off-chain mission-catalog row this run instantiated (the editor's `templateId`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "regionId",
+            "docs": [
+              "off 80 — the sector this mission belongs to (the `RegionOrderAnchor` PDA key). PINNED at start",
+              "from the fleet/starbase location, never caller-chosen at settle (convention #2)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "regionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "numCrew",
+            "docs": [
+              "off 82 — crew committed (the `reconcile` magnitude), verbatim `QuestProcess.num_crew`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardPage",
+            "docs": [
+              "off 84 — owner-pinned XP destination page, verbatim the quest fix. Required at settle when XP > 0."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardXp",
+            "docs": [
+              "off 86 — XP poured on WIN via `pour_xp`. **WIDENED u8 -> u16 vs `QuestProcess` (BUILD BLOCKER #0):",
+              "the quest path truncates at 255 AND clamps at `PERK_POINTS_MAX=10`; the mission settle does NEITHER.**"
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "successBps",
+            "docs": [
+              "off 88 — THE committed success target, 0..=10000. Computed off-chain (same `formula.js` the editor",
+              "previews) and committed at start, BEFORE the deciding entropy exists. The roll compares to this."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "commitSlot",
+            "docs": [
+              "off 90 — the slot `StartMission`/`ArmMissionSettle` landed in. The settle entropy is",
+              "`SlotHashes[commit_slot + REVEAL_DELAY]`. The anti-grind keystone."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stakeAtlas",
+            "docs": [
+              "off 98 — ATLAS (Floyds) escrowed at start; forfeit on loss/abort, refunded on win (editor knob)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stakeResourceId",
+            "docs": [
+              "off 106 — the single PRIMARY staked resource type (0 = none); multi-resource stakes live in the",
+              "vault map (§4.1). This caches the primary leg for the no-map-load refund math."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "cargoId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stakeResourceQty",
+            "docs": [
+              "off 108 — quantity of `stake_resource_id` escrowed (mirrored in the vault)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardPool",
+            "docs": [
+              "off 116 — the emissions-fed treasury this mission's WIN payout draws from. Pinned at start to the",
+              "`(game, region_id)` treasury; settle validates the supplied treasury equals this."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardAtlas",
+            "docs": [
+              "off 148 — the ATLAS (Floyds) paid on WIN, COMMITTED at start (the catalog's tier-scaled winAtlas).",
+              "On-chain so the per-epoch circuit-breaker — the only real inflation bound (00 §4 / H4) — caps it.",
+              "REFINEMENT over doc 10 §1.2, which omitted the reward amount: it must be committed to be",
+              "breaker-bounded (the settle has empty args + cannot trust the cranker for the payout size)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lootTableId",
+            "docs": [
+              "off 156 — the off-chain Loot-Matrix table id rolled on win; settle EMITS `(loot_table_id, roll)`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "startTime",
+            "docs": [
+              "off 160 — verbatim `QuestProcess.start_time`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "endTime",
+            "docs": [
+              "off 168 — verbatim `QuestProcess.end_time`; settle is time-gated `now >= end_time`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rollValue",
+            "docs": [
+              "off 176 — the settled draw (0..=9999) written at settle for the event/decoder/holosim echo."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "sectorWinDelta",
+            "docs": [
+              "off 178 — committed sector impact on WIN (+; off-chain PRE-SCALED = sectorDelta·tier_weight·regionMult)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "sectorLossDelta",
+            "docs": [
+              "off 180 — committed sector impact on LOSS (negative). The settle folds EXACTLY ONE into the anchor."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stanceSide",
+            "docs": [
+              "off 182 — Phase-2 faction-stance: NARRATIVE intent. 0=INCUMBENT, 1=CHALLENGER, 255=NONE (untagged",
+              "mission → the whole stance block is skipped at settle; full back-compat). Committed at StartMission."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "baseFaction",
+            "docs": [
+              "off 183 — the actor's faction at start, raw `Faction` repr as u8 (read from the VALIDATED",
+              "StarbasePlayer.faction — owner-signed, so re-citizenship between start and settle can't change it)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "sectorIncumbent",
+            "docs": [
+              "off 184 — the sector's rightful incumbent faction at start, raw `Faction` repr. Read TRUSTLESSLY",
+              "from `RegionTracker.regions[region_id].owner` (NEVER a caller arg). The own-faction gate is",
+              "`base_faction == sector_incumbent` (u8 equality — `Faction` is a niche enum, not `Pod`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pinnedOutlaw",
+            "docs": [
+              "off 185 — the RESOLVED outlaw status snapshotted at start (`outlaw==1 && now < pvp_until`); a",
+              "mid-mission `ClearOutlaw` cannot change this frozen byte. 0 when no OutlawFlag exists (fail-closed:",
+              "own-faction opposition stays BLOCKED)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad",
+            "docs": [
+              "off 186 — tail pad to the 188-byte boundary; forward-compat slack (reserved for the attrition trio",
+              "win_injury_bps/severity_table_id/overuse_band — a SEPARATE coordinated grow, doc-110 §3.2)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          }
+        ]
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "missionStakeVault",
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "56278266b69812fb",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "mission",
+            "docs": [
+              "The owning `MissionProcess` (the seed component)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "vault",
+            "docs": [
+              "Escrowed ATLAS (the player's stake). Same type as `EncounterTreasury.vault`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserves",
+            "docs": [
+              "Escrowed resources (the multi-resource stake legs)."
+            ],
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "cargoId"
+              },
+              "value": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "missionStakeVault"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "missionTreasury",
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "e6748a6b4d5b4d78",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "regionId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "regionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "vault",
+            "docs": [
+              "ATLAS reserve: pays win ATLAS, receives loss/abort forfeits. Same type as `LocalMarket.vault`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochStart",
+            "docs": [
+              "Per-epoch circuit-breaker (the hard inflation ceiling). Reset when `now >= epoch_start + epoch_len_secs`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochLenSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasOutThisEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasOutCapPerEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserves",
+            "docs": [
+              "Finite, pre-stocked cargo reserve. Wins draw down; loss/abort forfeits credit back. No minting."
+            ],
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "cargoId"
+              },
+              "value": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "missionTreasury"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "outlawFlag",
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "1368a01762dafdad",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "profile",
+            "docs": [
+              "The profile this flag belongs to (cross-checked by `AccountValidate`)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "faction",
+            "docs": [
+              "The faction this outlaw status is AGAINST — raw `Faction` repr as `u8` (Pod-safe; `Faction` is a",
+              "niche enum and is NOT `Pod`, so it cannot live on a `Pod` account; the PDA seed encodes it too)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "outlaw",
+            "docs": [
+              "1 = currently outlaw against `faction`, 0 = cleared."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "declaredAt",
+            "docs": [
+              "Unix ts the outlaw status was (last) declared."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pvpUntil",
+            "docs": [
+              "ABSOLUTE unix ts the commitment window ends (`declared_at + OUTLAW_WINDOW_EPOCHS * epoch_len_secs`).",
+              "Stored absolute (not an epoch count) — there is no native on-chain epoch counter; the window check",
+              "is a single `now >= pvp_until` compare and survives any epoch-length retune."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "outlawFlag"
+      },
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "accountNode",
+      "name": "regionOrderAnchor",
+      "data": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 8,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "b334788942095b3e",
+              "encoding": "base16"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "regionId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "regionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 4
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gameId",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "orderImpactAcc",
+            "docs": [
+              "THE ledger — signed, undecayed running sum of `±(sector_delta · tier_weight)` over all settles.",
+              "Off-chain decays this toward 0 (order relaxes to baseline) by time since `last_settle_ts`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i128",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "settleSeq",
+            "docs": [
+              "Monotonic settle counter (anti-replay / off-chain cursor)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastSettleTs",
+            "docs": [
+              "Unix ts of the last settle that moved the ledger (the off-chain decay clock)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          }
+        ]
+      },
+      "pda": {
+        "kind": "pdaLinkNode",
+        "name": "regionOrderAnchor"
       },
       "discriminators": [
         {
@@ -3771,6 +9224,128 @@
   "instructions": [
     {
       "kind": "instructionNode",
+      "name": "abortMission",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "missionProcess",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "Validated against BOTH the profile and starbase-player it stored (owner cross-check), closed on abort."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "missionVault",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The escrow vault — swept to the treasury (forfeit), then closed. Seed-validated to PDA(mission key);",
+            "the mission_process it's bound to is already owner+game validated, so the vault is transitively scoped."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardPool",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The treasury the forfeited stake recycles into (validated `== mission.reward_pool` in-handler)."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "9bee04e120a596f2",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "addCrewToGame",
       "accounts": [
         {
@@ -4564,6 +10139,450 @@
     },
     {
       "kind": "instructionNode",
+      "name": "adminCreateFleet",
+      "docs": [
+        "Create an NPC fleet at an arbitrary map location (admin only)",
+        "",
+        "Logic overview:",
+        "- Check that the profile has MANAGE_FLEET permissions",
+        "- Look up the ship definition from game state and compute fleet stats",
+        "- Create the fleet PDA and set it to Idle state at the given sector",
+        "",
+        "Unlike [`crate::instructions::CreateFleet`], this instruction:",
+        "- Does not require a `StarbasePlayer` or `Character` account",
+        "- Accepts explicit `sector` coordinates — fleet spawns anywhere on the map",
+        "- Populates ship stats directly from the on-chain ship definition registry",
+        "",
+        "Intended for NPC fleet spawning (nemesis-engine, npc-fleets)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileFaction",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Profile faction — determines the fleet's faction alignment"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The new [`Fleet`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The Solana System program"
+          ],
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "d0de873b81aef4f7",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "fleetLabel",
+          "docs": [
+            "Fleet label (padded to `MAX_NAME_LENGTH` bytes)"
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "name"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "shipId",
+          "docs": [
+            "Ship type to place in the fleet (must exist in `game.ship_definitions`)"
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "shipId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "shipAmount",
+          "docs": [
+            "Number of ships to add"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "sector",
+          "docs": [
+            "Starting sector coordinates `[x, y]`"
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 2
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "Index of the signing key in the player profile"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "adminDepositCargoToFleet",
+      "docs": [
+        "Deposit fuel and/or ammo directly into an NPC fleet (admin only)",
+        "",
+        "Logic overview:",
+        "- Check that the profile has MANAGE_FLEET_CARGO permissions",
+        "- Validate that the fleet belongs to the admin profile",
+        "- Directly increment `fuel_tank` and/or `ammo_bank` on the fleet account",
+        "up to the fleet's stat-derived capacity limits",
+        "",
+        "Unlike [`crate::instructions::TransferCargoToFleet`], this instruction:",
+        "- Does not require the fleet to be docked — works in any fleet state",
+        "- Does not transfer from a `StarbasePlayer` cargo pod — admin injects directly",
+        "- Only handles fuel and ammo (the two `SingleCargo` fields on Fleet)",
+        "",
+        "Intended for NPC fleet restocking without the normal player cargo flow",
+        "(nemesis-engine, npc-fleets)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The fleet to restock"
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "187f4dc48d32d759",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "fuelAmount",
+          "docs": [
+            "Amount of fuel to deposit (0 = no change)"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "ammoAmount",
+          "docs": [
+            "Amount of ammo to deposit (0 = no change)"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "Index of the signing key in the player profile"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "adminRemoveFleet",
+      "docs": [
+        "Remove an NPC fleet from non-mining states (admin only)",
+        "",
+        "Logic overview:",
+        "- Check that the profile has MANAGE_FLEET permissions",
+        "- Check that the fleet belongs to the admin profile",
+        "- Reject mining fleets because asteroid miner counters need cleanup",
+        "- Drop all cargo pod contents and close the fleet account",
+        "",
+        "Unlike [`crate::instructions::DisbandFleet`], this instruction:",
+        "- Does not require the fleet to be docked at a starbase",
+        "- Does not require a `StarbasePlayer`, `Character`, or system account",
+        "- Discards all ship and cargo data (NPC cleanup — nothing to return to a player)",
+        "- Accepts fleets in non-mining states (Idle, MoveSubwarp, MoveWarp, etc.)",
+        "",
+        "Intended for NPC fleet teardown (nemesis-engine, npc-fleets)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The fleet account to remove"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleetFactionOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b CONCURRENT-CAP (best-effort): the fleet's FLEET-kind `FactionOwnership` sidecar (Optional,",
+            "read-only) — present ⇔ an NPC fleet; supplies the controlling faction so its live `npc_fleet_count` is",
+            "freed on teardown. PDA seed-bound to `fleet`. Omitted ⇒ no-op, byte-identical."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "ownerFactionAccount",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b CONCURRENT-CAP: the controlling faction's registry account (Optional, Mut) — decremented when an",
+            "NPC fleet is released. REQUIRED ⇔ the sidecar names a dynamic faction (id > 3); PDA-bound in-handler."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "d1a33ec6b676ed29",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "Index of the signing key in the player profile"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "adminWithdrawAtlas",
       "docs": [
         "Withdraws ATLAS from a game vault",
@@ -4742,6 +10761,78 @@
             "kind": "numberTypeNode",
             "format": "u64",
             "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "advanceAtlasRewardEpoch",
+      "docs": [
+        "Permissionlessly advance the registry to the epoch containing the current clock timestamp."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "registry",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "activeConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Current active version, PDA-checked against registry data in `process`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "pendingConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Required exactly when the registry has a pending version."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "a6be5cac04fdf299",
+            "encoding": "base16"
           }
         }
       ],
@@ -5257,6 +11348,179 @@
     },
     {
       "kind": "instructionNode",
+      "name": "applyCombatStimulant",
+      "docs": [
+        "Applies one fleet-only combat stimulant from the fleet cargo hold.",
+        "",
+        "The resulting active stimulants are charge-based and live on the Fleet account. They are",
+        "applied to local combat-stat overlays at resolution time and never mutate Fleet.stats."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The fleet applying the stimulant. Must be crewed."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account containing cargo and stimulant definitions."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "96a1699681f5a459",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "stimCargoId",
+          "docs": [
+            "Cargo id of the stimulant item to consume from the fleet cargo hold."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "cargoId"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "armMissionSettle",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "crank",
+          "isWritable": false,
+          "isSigner": true,
+          "docs": [
+            "Permissionless crank — any signer (no rent moves; the process stays open for the later settle)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "starbasePlayer",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Read-only, for the process owner cross-check (no mutation here)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "missionProcess",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The process to arm — validated against its stored starbase-player. NOT closed (one-way arm)."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "ab5995561048f97a",
+            "encoding": "base16"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "attackFleet",
       "docs": [
         "Attack an enemy fleet.",
@@ -5367,7 +11631,7 @@
           "isWritable": true,
           "isSigner": false,
           "docs": [
-            "The [`Fleet`] account",
+            "The `Fleet` account",
             "Must be alive and have normalized crew"
           ]
         },
@@ -5432,6 +11696,15 @@
         },
         {
           "kind": "instructionAccountNode",
+          "name": "recentSlothashes",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Recent slot hashes used to seed combat outcome randomness"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
           "name": "systemProgram",
           "isWritable": false,
           "isSigner": false,
@@ -5453,6 +11726,117 @@
             "The asteroid that the defending fleet is mining",
             "Must be provided only if the defending fleet is mining"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionRelationTracker",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "P3 diplomacy combat-gate (REQUIRED — enforced, non-bypassable). Always passed (one tracker per game,",
+            "created by `InitFactionRelationTracker`). When `combat_gating_enabled == 0` the gate is a no-op",
+            "(behavior-identical to pre-P3 — same-faction is still enforced by `validate()`'s `!=`); when `1`, it",
+            "forbids attacking an Allied/active-Ceasefire faction inside that faction's OWNED territory."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "attackerFleetOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b: the ATTACKER fleet's `FactionOwnership(FLEET)` sidecar (Optional, read-only). Present ⇔ the",
+            "attacker is an NPC fleet — it supplies the dynamic controlling faction so `attacker_id` can resolve to",
+            "a minor id `> 3` (and the COMBATANT guard can bite). PDA seed-bound to `self.fleet`. Flag-OFF / a",
+            "player attack passes `None` ⇒ byte-identical to pre-P5b (the resolution falls back to the legacy enum).",
+            "Appended AFTER `crew_binding` so the canonical trailing-optional order is",
+            "asteroid → faction_relation_tracker → crew_binding → P5b's three (program-id-sentinel positional decode)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "defenderFleetOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b: the DEFENDER fleet's `FactionOwnership(FLEET)` sidecar (Optional, read-only). Resolves an NPC",
+            "defender's TRUE faction so the diplomacy gate + resolved same-faction guard don't mis-resolve it as",
+            "Unaligned (id 0). PDA seed-bound to `self.defending_fleet`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "attackerFactionAccount",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b: the attacker faction's registry account (Optional, read-only) — the COMBATANT capability guard",
+            "for a dynamic NPC attacker (`attacker_id > 3`). Its PDA is re-derived from the RESOLVED `attacker_id`",
+            "and `ensure_eq!`-bound in `process()`, so a caller can never pass a COMBATANT faction's account while",
+            "flying a non-COMBATANT faction's fleet."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "attackerRewardsRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "attackerRewardsConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "attackerRewardsEpoch",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "attackerRewardsContribution",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "defenderRewardsRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "defenderRewardsConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "defenderRewardsEpoch",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "defenderRewardsContribution",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -5617,7 +12001,7 @@
           "isWritable": true,
           "isSigner": false,
           "docs": [
-            "The [`Fleet`] account",
+            "The `Fleet` account",
             "Must be alive and have normalized crew"
           ]
         },
@@ -5672,6 +12056,15 @@
         },
         {
           "kind": "instructionAccountNode",
+          "name": "recentSlothashes",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Recent slot hashes used to seed combat outcome randomness"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
           "name": "systemProgram",
           "isWritable": false,
           "isSigner": false,
@@ -5682,6 +12075,111 @@
             "kind": "publicKeyValueNode",
             "publicKey": "11111111111111111111111111111111"
           }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionRelationTracker",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "P3 diplomacy combat-gate (REQUIRED — enforced, non-bypassable). Always passed (one tracker per game).",
+            "`combat_gating_enabled == 0` ⇒ no-op (pre-P3 behavior — same-faction still enforced by `validate()`);",
+            "`1` ⇒ forbids attacking an Allied/active-Ceasefire faction's starbase inside that faction's OWNED territory."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P4 dynamic-ownership sidecar for THIS starbase (Optional). REQUIRED ⇔ `dynamic_capture_enabled != 0`",
+            "(enforced in `process`, STEP 0). PDA proven by `Seeds` — the `game_id` seed makes the address",
+            "game-scoped (a wrong-game sidecar derives a different PDA ⇒ `AddressMismatch`); STEP 0 also asserts",
+            "`game_id` directly (defense-in-depth). Absent ⇒ pure legacy combat (pre-P4 behavior, byte-identical).",
+            "",
+            "NOTE (client SDKs): the seeds use the `starbase_seeds(...)` helper, which the IDL extractor cannot",
+            "introspect into a `pdaNode` (a const `asset_kind` seed is not expressible via `#[idl(arg = Seeds)]`).",
+            "Callers derive it by hand: `[b\"FactionOwnership\", game, &[0u8], system.to_bytes()]`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "attackerFleetOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b: the ATTACKER fleet's `FactionOwnership(FLEET)` sidecar (Optional, read-only). Present ⇔ an NPC",
+            "attacker — it resolves `attacker_id` to a dynamic minor id `> 3` so the COMBATANT path activates. PDA",
+            "seed-bound to `self.fleet`. Absent / nemesis OFF ⇒ legacy resolution (byte-identical to P4). Appended",
+            "AFTER `crew_binding` (canonical tail: faction_ownership → crew_binding → P5b's four)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "attackerFactionAccount",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b: the attacker faction's registry account (Optional, Mut). Serves BOTH the COMBATANT capability",
+            "guard for a dynamic NPC attacker AND the per-faction anti-blitz `last_capture_at` stamp on capture. Its",
+            "PDA is re-derived from the RESOLVED `attacker_id` in `process()` (capability-forgery defense)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionEconomicsConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b: the per-game NPC-economy dials (Optional, read-only) — the capture cooldown + cost. REQUIRED on a",
+            "dynamic NPC capture (so the anti-blitz cannot be dodged by omitting it)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "captorTreasury",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b: the captor faction's treasury (Optional, Mut) — debited `capture_cost_atlas` via the per-epoch",
+            "meter on a dynamic NPC capture (skin-in-the-game; a defunded faction cannot pay ⇒ self-quieting). Its",
+            "PDA is bound to `attacker_id` in STEP H."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardRegistry",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Event-time reward config and King tracker. Mandatory so a caller cannot omit tier rewards or",
+            "ownership-count maintenance when a starbase is downgraded/taken over."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "kingTracker",
+          "isWritable": true,
+          "isSigner": false
         }
       ],
       "arguments": [
@@ -5724,6 +12222,477 @@
           "type": {
             "kind": "definedTypeLinkNode",
             "name": "fleetStance"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "awardCrewActivityXp",
+      "docs": [
+        "`AwardCrewActivityXp` args. A batch of crew (by asset id) on one page, plus the per-category",
+        "XP to pour for the fleet's recent activity (`awards` indexed by",
+        "`CrewXpCategory`(crate.state.CrewXpCategory) — `awards[Mining]` etc.). The pour is divided",
+        "across the page's present crew (the §S.4 per-capita share); each named crew then realizes."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "06d3fe6c23fe43de",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetIds",
+          "docs": [
+            "The crew (by asset id) to realize after the pour. Typically the crew the fleet had",
+            "onboarded for the awarded activity."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            },
+            "count": {
+              "kind": "prefixedCountNode",
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              }
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "awards",
+          "docs": [
+            "Per-activity XP to credit, indexed by `CrewXpCategory`(crate.state.CrewXpCategory).",
+            "Each non-zero entry is poured into that category's per-capita accumulator; zeros are no-ops.",
+            "Every entry must be ≤ `crate.folds.xp.MAX_ACTIVITY_XP_AWARD_PER_CALL` (≈100 resolves'",
+            "worth) or the call rejects with `CrewXpAwardTooLarge` (PR #732 review — bounds the",
+            "caller-supplied pour rate)."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 5
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "The roster page the named crew live on."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "bindCrew",
+      "docs": [
+        "`BindCrew` args. Like `super.MigrateCrewMember` but binds a single, already-attested",
+        "crew sheet (the asset id + its current sheet snapshot is reconstructed on-chain from the",
+        "rarity/base-stat the same way migrate seeds it — a re-bind starts from the canonical seed",
+        "and re-levels via XP-on-touch)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review).",
+            "Validated against the signer's profile + game; the roster below must then BE this",
+            "character's `(character, page_index)` PDA (`ensure_roster_is_characters_page`)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewAuthority",
+          "isWritable": false,
+          "isSigner": true,
+          "docs": [
+            "The crew **attestation authority** — must equal `Game.crew_config` and must SIGN.",
+            "TEMPORARY hard gate (PR #732 second review): until the Phase-2 DAS/escrow attestation",
+            "lands, crew-record creation is closed to the configured authority (ops / the future",
+            "attestation oracle), so caller-supplied `rarity`/`base_stat` cannot be forged by",
+            "players even with the feature enabled. Phase 2 replaces this co-signature with",
+            "on-chain attestation verification."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "b5ab76c896b0a00d",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetId",
+          "docs": [
+            "The crew cNFT asset id to bind."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "rarity",
+          "docs": [
+            "DAS-attested rarity discriminant."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "baseStat",
+          "docs": [
+            "Rarity-derived base aptitude seed (as `migrate`)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "The roster page the supplied account must be."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
           }
         }
       ],
@@ -6605,6 +13574,121 @@
     },
     {
       "kind": "instructionNode",
+      "name": "cancelQuest",
+      "docs": [
+        "`CancelQuest` args — clones `CancelStarbaseUpgradeContribution` (cancel_rs:24-30): the",
+        "owner's profile `key_index`. Owner-only (NOT permissionless — only the owner cancels",
+        "early; once the timer elapses, anyone completes via the crank)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "questProcess",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The quest process — validated against BOTH the profile and starbase-player it stored",
+            "(the owner cross-check, cancel_rs:57-61), closed on cancel."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "cce832445ca96ec6",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "the index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "cancelRegionBorderUpload",
       "accounts": [
         {
@@ -7076,6 +14160,157 @@
     },
     {
       "kind": "instructionNode",
+      "name": "claimLoyaltyAtlas",
+      "docs": [
+        "Move the entire non-expired accumulated bank balance into the owner's in-game Character balance."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "bank",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "2277b9227224b89a",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "claimStakesRentTopUp",
       "docs": [
         "Top up rent for a claim stake instance",
@@ -7444,6 +14679,99 @@
     },
     {
       "kind": "instructionNode",
+      "name": "claimTerritoryYield",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": true,
+          "docs": [
+            "Permissionless cranker — pays tx fees only; the yield credits the controlling faction's treasury."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "system",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The starbase's system — supplies the legacy owner (resolution fallback) + the generation witness."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The STARBASE dynamic-ownership sidecar (Mut — the yield cursor is stamped). PDA-bound to the system."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Per-game reputation/yield dials (PDA-checked; supplies the yield rate + cadence)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionTreasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The CONTROLLING faction's treasury (Mut — vault credited). The PDA is re-derived from the resolved",
+            "controller in `process()` and compared (the controller is a data-dependent seed)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "currencyCache",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The game's central ATLAS source vault (the finite, admin-funded yield ceiling). Mut — debited."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "57126f8e6e8f472e",
+            "encoding": "base16"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "cleanupInvalidMarket",
       "docs": [
         "Permissionless instruction that cleans up an order from an invalid local market. Invalid markets happen when a starbase's",
@@ -7570,6 +14898,91 @@
           "defaultValue": {
             "kind": "bytesValueNode",
             "data": "ec83bbd473f57d6c",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "clearOutlaw",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "outlawFlag",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The actor's own flag (validated by profile); cleared ONLY after the commitment window expires."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "12d8f8dc18afc566",
             "encoding": "base16"
           }
         },
@@ -8752,6 +16165,102 @@
     },
     {
       "kind": "instructionNode",
+      "name": "completeQuest",
+      "docs": [
+        "`CompleteQuest` args — **no `key_index`** (this is permissionless; there is no profile to",
+        "validate). Empty arg, exactly as `TheOneFleetStateHandler` (generic_fleet_state_handler_rs:14-16)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": true,
+          "docs": [
+            "The funder for any Solana rent payments AND the rent-refund recipient for the closed",
+            "`QuestProcess` (the `CloseAccount` cleanup requires a registered recipient — the",
+            "cranker keeps the freed rent, the standard permissionless-crank incentive). The ONLY",
+            "signer (generic_fleet_state_handler_rs:22-23). Any cranker may settle an elapsed quest."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account (flag gate)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "starbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The starbase-player whose `busy_crew` the quest reserved — cross-checked against the",
+            "process's stored `starbase_player` key. `Mut` for the `reconcile(-N)` release.",
+            "ASSUMES (SAGE): a starbase-player account form addressable without the owner's profile",
+            "(the crank has no profile); the composite/validated form keyed by the process's stored",
+            "key. Modeled as the validated starbase-player; the integrator binds the exact",
+            "crank-friendly account. The auth binding is the `quest_process` cross-check below",
+            "(`#[validate(arg = (self.starbase_player.key_for(),))]`), NOT a profile — so this is a raw",
+            "`Mut<Account<StarbasePlayer>>` (no `ValidatedStarbasePlayer`, which needs a profile-derived",
+            "validation arg the permissionless crank cannot supply)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "questProcess",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The quest process being settled — validated against the starbase-player it stored",
+            "(the `KeyForFromAccountSet` cross-check, quest_rs:82-104), and **closed** on success",
+            "(the no-leak guarantee — install_rs:69). `Mut` + `CloseAccount` cleanup."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The owner's pinned reward roster page (`QuestProcess.reward_page`). Required when",
+            "`reward_xp > 0`; omitted only for reward-less quests."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "602265e8a4f6963d",
+            "encoding": "base16"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "completeShipRespawn",
       "docs": [
         "Completes ship respawning",
@@ -9038,6 +16547,13 @@
             "kind": "publicKeyValueNode",
             "publicKey": "11111111111111111111111111111111"
           }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -9103,6 +16619,226 @@
             "kind": "numberTypeNode",
             "format": "u16",
             "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "controllerSetFactionFlags",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "fdacacd90966e431",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "set",
+          "docs": [
+            "Bits to add."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "clear",
+          "docs": [
+            "Bits to remove."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "controllerUpdateFaction",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "7d8734dc8b7bde8c",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "nameHash",
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "contentUriHash",
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
           }
         }
       ],
@@ -10144,6 +17880,467 @@
     },
     {
       "kind": "instructionNode",
+      "name": "createEncounterTreasury",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterTreasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "d69a5098faeb2edd",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "regionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "regionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "minorFaction",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "createEncounterTreasuryArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "createFaction",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "f3a5bc73fa93fb0e",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "docs": [
+            "The faction id to mint (must be >= 4; `Init` reverts if it already exists)."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "createFactionArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "createFactionMarket",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The owning faction's record; bound to `faction_id` + must be Active (gate-before-create)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "system",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The anchoring star system; must contain a starbase. Supplies the `seq_id` 3rd seed."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionMarket",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "48823d503f33dff0",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "createFactionMarketArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "createFactionTreasury",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionTreasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "b476c807af1d1b45",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "createFactionTreasuryArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "createFleet",
       "docs": [
         "Create a fleet",
@@ -10356,6 +18553,135 @@
     },
     {
       "kind": "instructionNode",
+      "name": "createGearRecipe",
+      "docs": [
+        "`CreateGearRecipe` args — gear items ARE `Recipe` rows (master §6.1 A7). This is the",
+        "EXISTING `CreateRecipe` arg set (create_recipe_rs:12-21) under a crew-named alias: the",
+        "admin `key_index`, the `recipe_id`, and the recipe input data (inputs/fee/effect). No new",
+        "mint machinery — gear is crafted through the same recipe sink (reagents + ATLAS fee,",
+        "recipe_rs:80-83)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "recipe",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The gear recipe to create — `Init<Seeded<Account<Recipe>>>` with `Create(())` +",
+            "`Seeds(RecipeSeeds{ game_id, recipe_id })`, exactly as `CreateRecipe`",
+            "(create_recipe_rs:33-41)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The Solana System program."
+          ],
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "13f6b7231b784913",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "recipeId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "recipeId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "input",
+          "docs": [
+            "the recipe input data (inputs map, ATLAS `fee_amount`, the gear effect-family + tier)."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "createRecipeInputData"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "createLocalMarket",
       "docs": [
         "Initializes a new local market at a starbase",
@@ -10470,6 +18796,134 @@
           "type": {
             "kind": "definedTypeLinkNode",
             "name": "cargoId"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "createMissionTreasury",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The (game, region) reward pool, created here. Mirrors `CreateEncounterTreasury`'s Init+Seeds(arg)",
+            "threading; seeds = `MissionTreasurySeeds { game_id, region_id }` (region_id from the validate arg)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "acd3040582d0749d",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "regionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "regionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "epochLenSecs",
+          "docs": [
+            "per-epoch breaker window; `0` = breaker off (NOT recommended — the breaker is the inflation bound)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "i64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "atlasOutCapPerEpoch",
+          "docs": [
+            "the hard ATLAS-out ceiling per epoch (the only real on-chain inflation guard, H4)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
           }
         }
       ],
@@ -10618,16 +19072,15 @@
         "parameters. It performs authorization checks, ensures the region doesn't already exist,",
         "and initializes it with the provided configuration details.",
         "",
-        "The region is created with the specified id, owner faction, safety status, and optional",
-        "properties such as borders, connections, and research requirements. The provided border",
-        "is snapped to the region tracker's grid (`grid_k`), and adjacency (`neighbors_by_edge`)",
-        "is rebuilt to reflect shared edges with existing regions. Core systems can be associated",
-        "with the region by passing them as remaining accounts.",
+        "The region is created with the specified id, authored risk tier, border, connections,",
+        "and research requirements. The provided border is snapped to the region tracker's grid",
+        "(`grid_k`), and adjacency (`neighbors_by_edge`) is rebuilt to reflect shared edges with",
+        "existing regions. Ownership, safety, and effective risk are then derived from core-system",
+        "control and geometric adjacency.",
         "",
         "# Fields",
         "* `id` - Unique identifier for the region",
-        "* `owner` - The faction that will own this region (defaults to Unaligned if not provided)",
-        "* `safety_status` - The safety level of this region (defaults to Safe if not provided)",
+        "* `risk_zone` - The immutable authored/base risk tier",
         "* `connections` - Optional connections to other regions by ID",
         "* `border` - Optional region border coordinates",
         "* `scanning_research_requirements` - Optional technology requirements for scanning",
@@ -10890,6 +19343,109 @@
             "kind": "numberTypeNode",
             "format": "u16",
             "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "createRegionOrderAnchor",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "regionOrderAnchor",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "seeds = `RegionOrderAnchorSeeds { game_id, region_id }` (region_id from the validate arg)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "a4870f3bd4590207",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "regionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "regionId"
           }
         }
       ],
@@ -11690,6 +20246,122 @@
     },
     {
       "kind": "instructionNode",
+      "name": "declareOutlaw",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileFaction",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Proves faction enlistment — you may only outlaw against your OWN faction (cross-faction needs no flag)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "outlawFlag",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The per-(profile, faction) flag — created on first declare, EXTENDED on re-declare."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "2a62ddd4b26d4d27",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "faction",
+          "docs": [
+            "The faction to outlaw against — MUST be the actor's OWN enlisted faction (raw `Faction` repr as u8)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "deconstructClaimStakeInstance",
       "docs": [
         "Implementation of the DeconstructClaimStakeInstance instruction which removes a claim stake instance from a celestial body.",
@@ -11698,7 +20370,9 @@
         "The instruction performs the following operations:",
         "- Validates the claim stake instance exists and belongs to the actor",
         "- Ensures the claim stake instance is in active state (not in design)",
-        "- Verifies all buildings have been removed before deconstruction",
+        "- Verifies all player-funded buildings have been removed before deconstruction",
+        "- Discards the intrinsic bundled hub without refunding it as cargo",
+        "- Releases the hub's allocated crew",
         "- Removes the claim stake instance from the celestial body's claim stakes list",
         "- Returns the claim stake cargo to the starbase player's cargo pod",
         "- Closes the claim stake instance account to reclaim rent",
@@ -11706,7 +20380,7 @@
         "# Prerequisites",
         "",
         "Before deconstructing a claim stake instance:",
-        "- All buildings must be removed from the claim stake",
+        "- All player-funded buildings must be removed; the single bundled hub may remain",
         "- The claim stake must be in active state (not in design phase)",
         "- The actor must have MANAGE_CLAIM_STAKE permissions",
         "",
@@ -13195,6 +21869,398 @@
     },
     {
       "kind": "instructionNode",
+      "name": "devFundAtlasRewardTreasury",
+      "docs": [
+        "Non-production reserve credit for local/LiteSVM testing."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "670d4de97b0c8e45",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "cargoId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "cargoId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "amount",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "devFundEncounterTreasury",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The treasury to stock. Reserve growth (a new cargo key) reallocs it, funded by `profile`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "1317afa6c73d5ad1",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "atlasAmount",
+          "docs": [
+            "ATLAS to credit into the treasury vault (0 = skip)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "cargoId",
+          "docs": [
+            "Cargo to stock into the treasury reserve (paired with `cargo_amount`)."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "cargoId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "cargoAmount",
+          "docs": [
+            "Units of `cargo_id` to add to the reserve (0 = skip)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "devFundFactionTreasury",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The treasury to stock. Reserve/floor growth (a new cargo key) reallocs it, funded by `profile`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "ad9765635496ff78",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "atlasAmount",
+          "docs": [
+            "ATLAS to credit into the treasury vault (0 = skip)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "cargoId",
+          "docs": [
+            "Cargo to stock into the treasury reserve (paired with `cargo_amount`)."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "cargoId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "cargoAmount",
+          "docs": [
+            "Units of `cargo_id` to add to the reserve (0 = skip)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "setFloor",
+          "docs": [
+            "Optional: set/overwrite the per-cargo strategic-reserve FLOOR (faction-specific anti-drain) for `cargo_id`."
+          ],
+          "type": {
+            "kind": "optionTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            },
+            "prefix": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "disbandDestroyedFleet",
       "docs": [
         "Disbands a fleet that has been destroyed"
@@ -13313,6 +22379,30 @@
           "isSigner": false,
           "docs": [
             "The game account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleetFactionOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b CONCURRENT-CAP (best-effort): the fleet's FLEET-kind `FactionOwnership` sidecar (Optional,",
+            "read-only) — present ⇔ an NPC fleet; supplies the controlling faction so its live `npc_fleet_count` is",
+            "freed on teardown. PDA seed-bound to `fleet`. Omitted ⇒ no-op, byte-identical. ⚠ This is the",
+            "PERMISSIONLESS cleanup path: a caller may omit these to leave the slot occupied (best-effort cap)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "ownerFactionAccount",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b CONCURRENT-CAP: the controlling faction's registry account (Optional, Mut) — decremented when an",
+            "NPC fleet is released. REQUIRED ⇔ the sidecar names a dynamic faction (id > 3); PDA-bound in-handler."
           ]
         }
       ],
@@ -13460,7 +22550,7 @@
           "isWritable": true,
           "isSigner": false,
           "docs": [
-            "The [`Fleet`](crate::state::Fleet) account"
+            "The [`Fleet`] account"
           ]
         },
         {
@@ -13488,6 +22578,31 @@
           "isSigner": false,
           "docs": [
             "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleetFactionOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b CONCURRENT-CAP (best-effort): the fleet's FLEET-kind `FactionOwnership` sidecar (Optional,",
+            "read-only) — present ⇔ an NPC fleet; supplies the controlling faction so its live `npc_fleet_count` is",
+            "freed on teardown. PDA seed-bound to `fleet`. Omitted (player fleet / pre-P5b client) ⇒ no-op,",
+            "byte-identical."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "ownerFactionAccount",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b CONCURRENT-CAP: the controlling faction's registry account (Optional, Mut) — decremented when an",
+            "NPC fleet is released. REQUIRED ⇔ the sidecar names a dynamic faction (id > 3); PDA-bound to it",
+            "in-handler."
           ]
         }
       ],
@@ -13836,6 +22951,236 @@
           "name": "keyIndex",
           "docs": [
             "the index of the key in the player profile"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "equipGear",
+      "docs": [
+        "`EquipGear` args — equip one gear item into one physical slot."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "1d843b060ecca76f",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetId",
+          "docs": [
+            "The crew (by asset id) to equip onto."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "slotIdx",
+          "docs": [
+            "The physical slot index to equip into (`0..GEAR_SLOTS`; one item per slot)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "gearId",
+          "docs": [
+            "The gear definition id (`CargoId`; `0` is the empty sentinel and is rejected —",
+            "use `UnequipGear` to clear a slot)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "tier",
+          "docs": [
+            "The gear tier (`1..=5`; the magnitude is derived from this, master §4.4)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "durability",
+          "docs": [
+            "Starting durability of the equipped item."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "The roster page the crew lives on."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile."
           ],
           "type": {
             "kind": "numberTypeNode",
@@ -14969,6 +24314,13 @@
             "kind": "publicKeyValueNode",
             "publicKey": "11111111111111111111111111111111"
           }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -15317,6 +24669,29 @@
             "If mining, provide the asteroid being mined",
             "CHECK: validated against fleet mining state"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleetFactionOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b CONCURRENT-CAP (best-effort): the fleet's FLEET-kind `FactionOwnership` sidecar (Optional,",
+            "read-only) — present ⇔ an NPC fleet; supplies the controlling faction so its live `npc_fleet_count` is",
+            "freed on teardown. PDA seed-bound to `fleet`. Omitted ⇒ no-op, byte-identical."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "ownerFactionAccount",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P5b CONCURRENT-CAP: the controlling faction's registry account (Optional, Mut) — decremented when an",
+            "NPC fleet is released. REQUIRED ⇔ the sidecar names a dynamic faction (id > 3); PDA-bound in-handler."
+          ]
         }
       ],
       "arguments": [
@@ -15346,6 +24721,1093 @@
           "type": {
             "kind": "definedTypeLinkNode",
             "name": "shipId"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "fundAtlasRewardTreasuryCargo",
+      "docs": [
+        "Token-backed production funding for the finite combat-reward reserve."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "cargoCache",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "owner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "source",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "destination",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tokenProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "3356381f88b88481",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "amount",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "fundEncounterTreasury",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The treasury whose cargo reserve is being stocked. Reserve growth (a new cargo key) reallocs it."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "cargoCache",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game's cargo-definitions cache; owns the central per-mint custody ATAs."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "owner",
+          "isWritable": false,
+          "isSigner": true,
+          "docs": [
+            "The authority that owns the source token account and signs the transfer."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "source",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The source cargo-token account (owned by `owner`)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "destination",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The central custody ATA for the source mint (owned by `cargo_cache`)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tokenProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "6f7624e1ea1167e7",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "amount",
+          "docs": [
+            "Amount of the source mint's cargo token to deposit into the treasury reserve."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "fundEncounterTreasuryAtlas",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The treasury whose ATLAS vault is being funded (no resize → in-place credit)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "gameAtlasVault",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The game's central ATLAS vault ATA (owned by the currency cache)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "owner",
+          "isWritable": false,
+          "isSigner": true,
+          "docs": [
+            "The authority that owns the source token account and signs the transfer."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "source",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The source ATLAS token account (owned by `owner`)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "currencyCache",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "currencyCache",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "43757272656e6379436f6e666967",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tokenProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "0630acd77b94c8a0",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "amount",
+          "docs": [
+            "ATLAS (Floyds) to deposit into the treasury vault."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "fundFactionTreasuryAtlas",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The treasury whose ATLAS vault is funded (no resize → in-place credit)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "gameAtlasVault",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The game's central ATLAS vault ATA (owned by the currency cache)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "owner",
+          "isWritable": false,
+          "isSigner": true,
+          "docs": [
+            "The authority that owns the source token account and signs the transfer."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "source",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The source ATLAS token account (owned by `owner`)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "currencyCache",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "currencyCache",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "43757272656e6379436f6e666967",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tokenProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "d560a979f7d0af1c",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "amount",
+          "docs": [
+            "ATLAS (Floyds) to deposit into the treasury vault."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "fundFactionTreasuryCargo",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The treasury whose cargo reserve is stocked. A new cargo key reallocs it."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "cargoCache",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game's cargo-definitions cache; owns the central per-mint custody ATAs."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "owner",
+          "isWritable": false,
+          "isSigner": true,
+          "docs": [
+            "The authority that owns the source token account and signs the transfer."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "source",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The source cargo-token account (owned by `owner`)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "destination",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The central custody ATA for the source mint (owned by `cargo_cache`)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tokenProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "cb74a4bc56b89144",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "amount",
+          "docs": [
+            "Amount of the source mint's cargo token to deposit into the treasury reserve."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "setFloor",
+          "docs": [
+            "Optional: set/overwrite the per-cargo strategic-reserve FLOOR (anti-drain) in the same tx."
+          ],
+          "type": {
+            "kind": "optionTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            },
+            "prefix": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "fundMissionTreasuryAtlas",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "gameAtlasVault",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "owner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "source",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "currencyCache",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tokenProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "5a9b55287e692ce8",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "amount",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "grantXp",
+      "docs": [
+        "Grants `amount` XP in `category` to the character. Privileged",
+        "(`SagePermissions::MANAGE_PROGRESSION`): used to step a character through the",
+        "council-rank paths (e.g. testnet progression / the \"step through\" UI that replaces",
+        "God Mode), rather than earning XP through gameplay.",
+        "",
+        "Mirrors how every gameplay XP source awards XP: it calls `collect_xp`, which also",
+        "rolls the amount into the `CouncilRank` category automatically, so granting any",
+        "career-category XP advances council rank exactly as natural play would."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The character (owned by the signer's profile) to grant XP to."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account (provides the XP thresholds used to recompute levels)."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "df9319fc5bed7cd5",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "category",
+          "docs": [
+            "The XP category to grant into. Granting any non-`CouncilRank` career category also",
+            "increments `CouncilRank` (see `collect_xp`)."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "xpCategory"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "amount",
+          "docs": [
+            "The amount of XP to grant."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
           }
         }
       ],
@@ -15592,7 +26054,7 @@
           "isWritable": true,
           "isSigner": false,
           "docs": [
-            "The [`Fleet`](crate::state::Fleet) account"
+            "The `Fleet`(crate.state.Fleet) account"
           ]
         },
         {
@@ -15601,7 +26063,7 @@
           "isWritable": false,
           "isSigner": false,
           "docs": [
-            "The CSS [`StarSystem`] account"
+            "The CSS `StarSystem` account"
           ]
         },
         {
@@ -15621,6 +26083,13 @@
           "docs": [
             "The game account"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -15647,6 +26116,223 @@
           "docs": [
             "index of the key in the player profile"
           ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initAtlasRewardConfig",
+      "docs": [
+        "Create version 0 and the per-game epoch registry. The first config is forced disabled; activation is",
+        "a separately reviewable `UpdateAtlasRewardConfig` that takes effect at the next boundary."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "registry",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardConfig",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "7e291336209495ee",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "epochOffsetSecs",
+          "docs": [
+            "Initial UTC alignment offset. `0` means ordinary UTC-day boundaries for a 86,400-second epoch."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "i64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "values",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "atlasRewardConfigInitValues"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initAtlasRewardTreasury",
+      "docs": [
+        "Create the empty game-level finite cargo reserve used only by medallion and synthetic-salvage rewards."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "8a60cf5f7a9480c1",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
           "type": {
             "kind": "numberTypeNode",
             "format": "u16",
@@ -15768,6 +26454,567 @@
     },
     {
       "kind": "instructionNode",
+      "name": "initFactionEconomicsConfig",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionEconomicsConfig",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "f50514a769634339",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "factionEconomicsDials"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initFactionEpochMeter",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionEpochMeter",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "3df2cf6443165d3f",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initFactionOwnership",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "system",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Required for a starbase sidecar so the generation witness and King ownership are",
+            "derived from canonical live state. Must be omitted for fleet/region sidecars."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "kingTracker",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "e61b48fe70ec034b",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "assetKind",
+          "docs": [
+            "STARBASE=0 / FLEET=1 / REGION=2 (the mandatory seed discriminator)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "assetKey",
+          "docs": [
+            "Canonical 32-byte identity (the 3rd seed) — for STARBASE this is `system.pubkey().to_bytes()`."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "initFactionOwnershipArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initFactionRelationTracker",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionRelationTracker",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "bf1019d42e247ae9",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initFactionStanding",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The target faction's record (game-scoped); the handler binds it to `faction_id` and checks the gate."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionStanding",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "8503bb2df07155c5",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "initGame",
       "accounts": [
         {
@@ -15840,6 +27087,366 @@
           "type": {
             "kind": "numberTypeNode",
             "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initKingSystemTracker",
+      "docs": [
+        "Create the per-game fixed-width tracker. It starts empty so a clean deployment can create it before",
+        "the universe map; `SetKingSystems` must author all 69 systems before rewards are enabled."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tracker",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "4f355239cd77a44f",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initLoyaltyAtlasBank",
+      "docs": [
+        "Create a profile's bounded, persistent accumulated-ATLAS bank for one major faction."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profile",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "bank",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "7063fb8e8630deb7",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initLoyaltyContribution",
+      "docs": [
+        "Create a profile's zero-value contribution account for one open faction epoch."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profile",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "loyaltyEpoch",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "contribution",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "c1ee62d1057af208",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "epochIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "initLoyaltyEpoch",
+      "docs": [
+        "Create one major faction's current open epoch."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "registry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "activeConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "PDA-checked against the registry's active version in `process`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "loyaltyEpoch",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "77fc8e58179fe523",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "epochIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
             "endian": "le"
           }
         }
@@ -15949,6 +27556,38 @@
           "docs": [
             "The game account"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsEpoch",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsContribution",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "kingTracker",
+          "isWritable": true,
+          "isSigner": false
         }
       ],
       "arguments": [
@@ -16084,6 +27723,201 @@
     },
     {
       "kind": "instructionNode",
+      "name": "levelUpCrew",
+      "docs": [
+        "`LevelUpCrew` args. A batch of crew asset ids to realize on the named page (a crank can",
+        "realize many at once; each is O(1)). The `fleet_xp_accumulator` is the current per-capita",
+        "accumulator the crew earn against — supplied by the caller from the fleet's roster",
+        "summary (the read-half; the write-half advances each record's snapshot to it)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "3d731e3437e51bfe",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetIds",
+          "docs": [
+            "The crew (by asset id) to realize XP for."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            },
+            "count": {
+              "kind": "prefixedCountNode",
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              }
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "The roster page the crew live on."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "loadFleetCrew",
       "docs": [
         "Load crew onto a fleet",
@@ -16196,6 +28030,640 @@
           "name": "keyIndex",
           "docs": [
             "the index of the key in the player profile"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "loadFleetCrewRoster",
+      "docs": [
+        "`LoadFleetCrewRoster` args — the individuated load body. **NOT** wire-compatible with the",
+        "fungible `FleetCrewInput { count, key_index }` (precisely why this is a *separate* instruction",
+        "with its own disc): a passenger `count`, the specific `crew_asset_ids` to flip `OnFleet`, the",
+        "`page_index`, and the profile `key_index`. Empty `crew_asset_ids` ⇒ the fungible-core path",
+        "(count only) — still under THIS instruction's discriminator, never the legacy fungible one."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The `Fleet` account (fleet_crew_rs:38-43)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review).",
+            "Validated against the signer's profile + game; a supplied roster must then BE this",
+            "character's `(character, page_index)` PDA, so loading ANOTHER player's crew into",
+            "this fleet (and stealing their bonuses into the binding) is impossible."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The crew roster page holding the named individuated crew. Append-last optional."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "e24097be1e79ddcd",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "count",
+          "docs": [
+            "passenger count (the fungible quantity; preserved exactly, fleet_crew_rs:19)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetIds",
+          "docs": [
+            "The specific crew (by asset id) to flip `AtStarbase → OnFleet`. Empty ⇒ fungible-only",
+            "(no individuated records touched). When non-empty its `len()` must equal `count`."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            },
+            "count": {
+              "kind": "prefixedCountNode",
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              }
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "the roster page the named crew live on."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "the index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "shipId",
+          "docs": [
+            "PER-SHIP POSTING (appended last so the pre-posting payload is a strict prefix): the",
+            "ship MODEL (raw `ShipId`) within the fleet to post the named crew to. `0` = fleet pool",
+            "(no posting — exactly the pre-posting behavior). Non-zero ⇒ validated against",
+            "`Game.ship_definitions` and the fleet's own composition, with a per-model seat cap;",
+            "the posted crew's aptitude contribution to the per-fleet average is weighted by the",
+            "model's `required_crew` (snapshotted on the record). One model per call — batch",
+            "multiple calls to post across models."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "markCrewGarrison",
+      "docs": [
+        "`MarkCrewGarrison` args. A signed `delta` so one instruction both garrisons (`+N`) and",
+        "releases (`-N`) — symmetric, mirroring `reconcile_crew_allocation`'s signed diff."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "garrisonConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The per-level garrison-cap config (A8 — a SEPARATE account, never a `StarbaseLevelInfo`",
+            "append; red-team R3). Read-only: supplies `max_garrison_crew` for the cap check.",
+            "ASSUMES (SAGE): the A8 account type + its cap accessor."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "2f7f13476006ebda",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "the index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewDelta",
+          "docs": [
+            "signed crew delta: `> 0` garrisons (reserve `AtStarbase → Busy`), `< 0` releases",
+            "(`Busy → AtStarbase`). Routes through the PUBLIC `reconcile_crew_allocation(delta)`."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "i32",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "migrateCrewMember",
+      "docs": [
+        "`MigrateCrewMember` args. `#[ix_args(&run)]` + the `key_index` validate-arg is the EXACT",
+        "shape of `AddCrewToGame` (add_crew_to_game_rs:14-20): the profile key index drives the",
+        "`ProfileValidation`, the `Vec<CrewMigrateInput>` is the run-arg batch."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account (carries the `crew_config` off-switch in its packed header)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review).",
+            "Validated against the signer's profile + game; the roster below must then BE this",
+            "character's `(character, page_index)` PDA (`ensure_roster_is_characters_page`)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewAuthority",
+          "isWritable": false,
+          "isSigner": true,
+          "docs": [
+            "The crew **attestation authority** — must equal `Game.crew_config` and must SIGN.",
+            "TEMPORARY hard gate (PR #732 second review): until the Phase-2 DAS/escrow attestation",
+            "lands, crew-record creation is closed to the configured authority (ops / the future",
+            "attestation oracle), so caller-supplied DAS traits cannot be forged by players even",
+            "with the feature enabled. Phase 2 replaces this co-signature with on-chain",
+            "attestation verification."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The crew roster page to append onto (`page_index`-validated at the handler). The",
+            "append-last optional roster. `Mut` because we mutate the `List` tail + cached census."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "6bf9043788cfcc9a",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "items",
+          "docs": [
+            "The crew to bind this call (DAS-attested rarities)."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "definedTypeLinkNode",
+              "name": "crewMigrateInput"
+            },
+            "count": {
+              "kind": "prefixedCountNode",
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              }
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "The page index the supplied roster account must be (paginated whales, master §5)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile."
           ],
           "type": {
             "kind": "numberTypeNode",
@@ -16391,6 +28859,599 @@
           "defaultValue": {
             "kind": "bytesValueNode",
             "data": "d03f876cdafc2400",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "mintNpcCrewCapacity",
+      "docs": [
+        "Struct for data input to Mint NPC Crew Capacity"
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "starbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The `StarbasePlayer` account to add crew capacity to."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "243b0804041062cd",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the permissions profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "amount",
+          "docs": [
+            "The amount of fungible crew to add to the `StarbasePlayer`."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "mintNpcFleet",
+      "docs": [
+        "Mint a faction-owned NPC fleet (admin + operator co-signed).",
+        "",
+        "Logic overview (process order):",
+        "1. The faction must be `Active`.",
+        "2. The signing operator profile must EQUAL `FactionAccount.operator_profile` (else `FleetNotOwnedByFaction`).",
+        "3. `npc_fleet_count < max_npc_fleets`, UNCONDITIONALLY (the primary anti-flood brake; `FactionFleetCapExceeded`).",
+        "4. The initial directive byte must be a known, non-`NemesisHunt` kind (`InvalidFleetDirective`).",
+        "5. Spend `npc_mint_cost_atlas` from the treasury via `spend_metered` — the per-epoch ATLAS-out meter AND a fail-closed vault debit (a defunded faction reverts).",
+        "6. Init the `Fleet` exactly as `CreateFleet` does (owner = operator, `sub_profile = NONE`) + `register_fleet()`.",
+        "7. Init the FLEET `FactionOwnership` sidecar (controller = faction) and write the initial directive.",
+        "8. Bump `npc_fleet_count`."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "adminSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "adminProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "adminCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "adminProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileFaction",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The OPERATOR profile's faction account (supplies the legacy `Faction` alignment stamped onto the fleet,",
+            "verbatim `CreateFleet`)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The OPERATOR's character that belongs to [`Self::game`] (the fleet-registration concurrency bump),",
+            "verbatim `CreateFleet`."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`Fleet`] account — initialized exactly as `CreateFleet` does (owner = operator profile)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The faction's registry account (`Mut` — `npc_fleet_count` is bumped). Game-scoped here; its PDA is",
+            "re-derived from `faction_id` and `ensure_eq!`-bound in `process()` (the `ClaimTerritoryYield` idiom for",
+            "a faction account that is both game-scoped AND identity-pinned — `ValidatedAccount`'s validate arg is",
+            "the `AccountValidate` arg only, so the seed proof is done in-handler)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The FLEET dynamic-ownership sidecar — created here (the fleet's faction tag + directive payload). PDA",
+            "derived from the freshly-init fleet's key under the FLEET asset-kind, so it cannot collide with a",
+            "starbase sidecar over the same raw key."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionTreasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The faction's treasury (`Mut` — `spend_metered` rolls the per-epoch ATLAS-out meter AND debits the",
+            "vault). Game-scoped",
+            "here; its PDA is re-derived from `faction_id` and `ensure_eq!`-bound in `process()` (verbatim the",
+            "`fund_treasury` load form + the `ClaimTerritoryYield` seed-bind). One treasury per faction."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionEconomicsConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The per-game NPC-economy dials (supplies `npc_mint_cost_atlas`). Game-scoped here (the",
+            "`AccountValidate` impl asserts `game_id == game`); its PDA is per-game (`[seed, game_id]`) so the",
+            "game-scope alone pins identity — re-derived + `ensure_eq!`-bound in `process()` as defense in depth."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The Solana System program."
+          ],
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "4654633fedce4542",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "fleetLabel",
+          "docs": [
+            "The fleet label (the operator profile's fleet seed component — clone of `CreateFleet::fleet_label`)."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "name"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "operatorKeyIndex",
+          "docs": [
+            "The OPERATOR profile's signing key index (the fleet owner + treasury spender)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "adminKeyIndex",
+          "docs": [
+            "The ADMIN (`MANAGE_FACTIONS`) profile's signing key index (the co-signer that authorizes the spawn)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "docs": [
+            "The faction to mint for (seeds the faction account / treasury; must be `Active` and own the operator)."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "initialDirective",
+          "docs": [
+            "Initial directive kind byte (`FleetDirectiveKind`; `NemesisHunt`/unknown rejected). Run-only."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "aggression",
+          "docs": [
+            "Initial off-chain aggression dial (0–100; no on-chain rate consequence). Run-only."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "openEncounterTracking",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterCommit",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "261c4f9c14e674a1",
             "encoding": "base16"
           }
         },
@@ -17138,6 +30199,20 @@
         },
         {
           "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "P5 Bridge #2 (REQUIRED, fail-closed): the starbase's `FactionOwnership(STARBASE)` sidecar. A REQUIRED,",
+            "PDA-bound account that MAY be uninitialized — so the displaced legacy owner can no longer keep placing",
+            "buildings on a captured starbase by OMITTING it (this is a control/mutation gate, so omission is worse",
+            "here than at the dock). When initialized, the owner gate resolves via the dynamic controller",
+            "(witness-checked); uninitialized PDA ⇒ legacy gate (byte-identical to pre-P5). See",
+            "`resolve_starbase_controller_fail_closed`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
           "name": "systemProgram",
           "isWritable": false,
           "isSigner": false,
@@ -17235,12 +30310,14 @@
     },
     {
       "kind": "instructionNode",
-      "name": "placeClaimStakeInstance",
+      "name": "placeClaimStakeInstanceWithHub",
       "docs": [
-        "Implementation of the PlaceClaimStakeInstanceIx which places a new claim stake instance onto a CelestialBody.",
+        "Implementation of the PlaceClaimStakeInstanceWithHubIx which places a new claim stake instance onto a CelestialBody.",
         "",
         "This instruction allows actors to add a `ClaimStakeInstance` to a target `CelestialBody`.",
-        "- Appends a new claim stake instance to the celestial body's claim_stakes list.",
+        "- Validates and installs the matching zero-cost bundled hub.",
+        "- Applies the hub's derived stats and reserves its required crew.",
+        "- Appends the new claim stake instance to the celestial body's claim_stakes list.",
         "",
         "# System Context",
         "This instruction is part of the broader claim stake system that enables staking on celestial bodies.",
@@ -17465,7 +30542,7 @@
           },
           "defaultValue": {
             "kind": "bytesValueNode",
-            "data": "c0478c7e4379a140",
+            "data": "a385796890e23cc7",
             "encoding": "base16"
           }
         },
@@ -17485,11 +30562,22 @@
           "kind": "instructionArgumentNode",
           "name": "claimStakeDefinitionId",
           "docs": [
-            "The claim stake cargo id"
+            "The claim stake definition to place"
           ],
           "type": {
             "kind": "definedTypeLinkNode",
             "name": "claimStakeDefinitionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "hubBuildingId",
+          "docs": [
+            "The planet- and family-matched hub bundled with this stake"
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "buildingId"
           }
         },
         {
@@ -18261,6 +31349,284 @@
     },
     {
       "kind": "instructionNode",
+      "name": "reapExpiredMarket",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The Profile that funded the market at reveal; receives the rent refund (pinned by address)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account (scopes the market)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterMarket",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The expired market to close; rent flows to `funder`."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "ba783619936b5056",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "Unused — present only for interface parity with the other permissionless close instructions."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "reconcileKingSystem",
+      "docs": [
+        "Recompute one tracked system from canonical starbase state. The dynamic-ownership sidecar is optional;",
+        "when present it must be the exact starbase PDA. Level0 always counts for nobody."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "starSystem",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "ownership",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tracker",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "92e85fc552e3e487",
+            "encoding": "base16"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "recoverClaimStakesFleetTransfer",
+      "docs": [
+        "Recover a fleet from a stuck claim-stake transfer where the queued cargo",
+        "cannot be delivered exactly.",
+        "",
+        "Exists because:",
+        "- ExitClaimStakesFleetTransfer resolves the snapshotted transfer exactly.",
+        "If either source pod no longer contains the queued cargo, or the",
+        "destinations cannot fit it, the swap aborts and the fleet stays stuck in",
+        "FleetState::ClaimStakeTransfer.",
+        "- [`ForceExitClaimStakesFleetTransfer`](crate::instructions::ForceExitClaimStakesFleetTransfer)",
+        "requires the destination claim-stake account to have been evicted /",
+        "closed by the SAGE program, which does not help a fleet whose",
+        "destination stake is still active.",
+        "",
+        "Trigger condition: the transfer lock has elapsed and the queued snapshot",
+        "cannot execute exactly against the current fleet/stake cargo state. This",
+        "includes source shortfalls in either direction, invalid cargo ids, or",
+        "destination capacity overflow. If the planned cargo is currently",
+        "executable, the instruction errors and the player must use the normal exit",
+        "path.",
+        "",
+        "Access control: the fleet must belong to the signing profile, gated on",
+        "SagePermissions::MANAGE_FLEET_CARGO (the same permission required to",
+        "start the transfer). Only the fleet owner can recover their own fleet;",
+        "the destination claim-stake account is read-only and does not need to sign.",
+        "It is used only to prove that the transfer's queued stake-side cargo cannot",
+        "complete.",
+        "",
+        "Effects: sets the fleet back to [`FleetState::Idle`] at its current",
+        "location. No cargo movement, no atlas movement, no stake-side state",
+        "change. Any stake-side bookkeeping that references this transfer becomes",
+        "stale and can be cleaned up by the stake owner via normal stake",
+        "operations."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`Fleet`](crate::state::Fleet) account, must belong to the profile."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "claimStakeInstance",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The active claim stake instance referenced by the fleet transfer."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account"
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "9732d9dbd367e368",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the profile permissions"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "registerCelestialBody",
       "docs": [
         "Struct for data input to Register CelestialBody"
@@ -18471,6 +31837,122 @@
     },
     {
       "kind": "instructionNode",
+      "name": "registerEncounterPool",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterPool",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "d0f4cabc1c6efa1a",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "regionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "regionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "minorFaction",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "registerEncounterPoolArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "registerStarbase",
       "docs": [
         "Struct for data input to Register `Starbase`"
@@ -18523,6 +32005,24 @@
         {
           "kind": "instructionAccountNode",
           "name": "regionTracker",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "kingTracker",
           "isWritable": true,
           "isSigner": false
         },
@@ -18657,6 +32157,57 @@
             "kind": "publicKeyValueNode",
             "publicKey": "11111111111111111111111111111111"
           }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionRelationTracker",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "P3 dock-compose gate (OPTIONAL — a DELIBERATE deviation from the build-plan's required-tracker).",
+            "Dock-compose EXPANDS access (own / Allied / standing), so omitting this ⇒ own-faction-only docking",
+            "(STRICTER, not a bypass — a Hostile/foreign player still can't dock by omitting it). The plan's",
+            "required-tracker SEC-3 rationale (\"a forged/absent tracker bypasses the gate\") is a RESTRICTION-gate",
+            "concern (cf. the combat-gate, which IS required); it does NOT apply to this deny-by-default",
+            "expansion-gate: absent ⇒ denied, forged ⇒ `AccountValidate` (`GameMismatch`) reverts. When present +",
+            "`territory_access_enabled == 1`, admits Allied / high-standing players."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionStanding",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "OPTIONAL: the player's standing vs the STARBASE-OWNER faction. Omit ⇒ no standing override. Read-only",
+            "(no fee/accrual). PDA + identity bound (game, player profile, owner faction id) in process()."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "OPTIONAL: per-game reputation dials (supplies dock_min_band + decay). Supply WITH faction_standing."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "P5 Bridge #1 (REQUIRED, fail-closed): the starbase's `FactionOwnership(STARBASE)` sidecar. It is a",
+            "REQUIRED, PDA-bound account that MAY be uninitialized — so a displaced legacy owner can no longer dodge",
+            "dynamic ownership by OMITTING it. When initialized, dock admission resolves the owner via the dynamic",
+            "controller (witness-checked) instead of the legacy `Starbase.owner` enum, so a captured starbase's dock",
+            "access follows the captor. Uninitialized PDA ⇒ legacy resolution (byte-identical to pre-P5). See",
+            "`resolve_starbase_controller_fail_closed`."
+          ]
         }
       ],
       "arguments": [
@@ -19673,6 +33224,32 @@
           "docs": [
             "The game account"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsEpoch",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsContribution",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -19806,6 +33383,32 @@
           "docs": [
             "The game account"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsEpoch",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsContribution",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -19935,6 +33538,32 @@
           "docs": [
             "The game account"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsEpoch",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardsContribution",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -19985,6 +33614,88 @@
               "format": "u8",
               "endian": "le"
             }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "resolveCombatRewards",
+      "docs": [
+        "Resolve medallions and at most one weighted salvage outcome per committed death leg. Combat never",
+        "depended on reserve availability: awards clamp to finite stock and emit an observable low-stock log."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "config",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "loot",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "recentSlothashes",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "7c4a3bbc921d54ef",
+            "encoding": "base16"
           }
         }
       ],
@@ -20812,6 +34523,220 @@
     },
     {
       "kind": "instructionNode",
+      "name": "respecPerks",
+      "docs": [
+        "`RespecPerks` args — wipe all perks on one crew (refunding its slots, NOT its lifetime",
+        "points: respec re-rolls the *allocation*, the lifetime budget is spent-history). Charges an",
+        "ATLAS fee (the sink)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account (flag gate; also where the respec ATLAS fee is configured — `RESPEC_*`",
+            "price sheet, master §9)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "atlasSource",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The player's ATLAS source token account (debited the respec fee — the sink)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "atlasVault",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The ATLAS sink vault (credited; EXISTING `atlas_vault`/`dao_atlas_vault`)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tokenProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The SPL token program for the ATLAS transfer."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "984e48bdb7b57502",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetId",
+          "docs": [
+            "The crew (by asset id) to respec."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "The roster page the crew lives on."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "retrieveLoot",
       "docs": [
         "Attack an enemy fleet.",
@@ -21026,6 +34951,347 @@
     },
     {
       "kind": "instructionNode",
+      "name": "revealEncounter",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterCommit",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The player's pending commit (game-scoped; ownership re-checked in the handler). Cleared on reveal."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "pool",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The (region, faction) envelope — validated to match the committed zone + be active."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The matching treasury — read here only to clamp sell quantities to available stock."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterMarket",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The player-funded, time-boxed market to open (bound to the owner's character via seeds)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "recentSlothashes",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "0443b47ebdf96065",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "rollAtlasRewardEpoch",
+      "docs": [
+        "Close all three faction epochs, reserve their ATLAS, activate the next config, and create all three",
+        "next epochs atomically. It advances exactly one epoch, even when a keeper is late."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "registry",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "activeConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "pendingConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "kingTracker",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "mudEpoch",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "oniEpoch",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "usturEpoch",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "mudTreasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "oniTreasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "usturTreasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "nextMudEpoch",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "nextOniEpoch",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "nextUsturEpoch",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "2a3cf05f3ed79b35",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "closingEpochIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "nextEpochIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "scan",
       "docs": [
         "Scan.",
@@ -21160,6 +35426,43 @@
           "name": "recentSlothashes",
           "isWritable": false,
           "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "regionTracker",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterCommit",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Optional (Phase 2 — encounter): the caller's per-character [`EncounterCommit`], stamped when an encounter arms."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterPool",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Optional (Phase 2 — encounter): the `(region, faction)` [`EncounterPool`] the caller is arming. Its",
+            "faction is PINNED into the commit here — before the reveal's future hash exists — so it can't be",
+            "steered after the entropy is knowable. Validated active + same-region at scan; reveal requires the",
+            "revealed pool's faction to match. Must be supplied with `region_tracker` + `encounter_commit` to arm."
+          ]
         }
       ],
       "arguments": [
@@ -21187,6 +35490,2055 @@
             "kind": "numberTypeNode",
             "format": "u16",
             "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "seedMajorFactions",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "mud",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "oni",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "ustur",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "a3ae39f3a1b41c30",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setContested",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "e4cc2ecb5fbc3c16",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "assetKind",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "assetKey",
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "setContestedArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setCrewConfig",
+      "docs": [
+        "`SetCrewConfig` args — set (or clear) the `Game.crew_config` `OptionalPubkey`, the master",
+        "feature flag. `Some(key)` switches the whole crew layer ON; `None` switches it OFF (the",
+        "shipped default — flipping back to `None` is the instant, no-redeploy rollback).",
+        "",
+        "**The stored key is ALSO the crew attestation authority** (PR #732 second review):",
+        "`BindCrew` / `MigrateCrewMember` require it as a co-signer, so record creation stays",
+        "closed to the configured authority (ops / the future attestation oracle) until Phase-2",
+        "on-chain attestation verification replaces the co-signature. Setting a key nobody holds",
+        "keeps the feature ON for gameplay while binds stay closed; rotating the authority is one",
+        "admin call."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The game account — `Mut` to write `crew_config`. Validated against the admin profile",
+            "(the EXISTING `Game` admin validate arg, create_recipe_rs:30-31)."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "16691c55917079c2",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "the index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewConfig",
+          "docs": [
+            "the new `crew_config` value: `Some` ⇒ ON (the key doubles as the crew attestation",
+            "authority that must co-sign Bind/Migrate), `None` ⇒ OFF."
+          ],
+          "type": {
+            "kind": "optionTypeNode",
+            "item": {
+              "kind": "publicKeyTypeNode"
+            },
+            "prefix": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setEncounterPoolStatus",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterPool",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "fedafe5239ace49f",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "active",
+          "docs": [
+            "`true` → `Active` (spawnable); `false` → `Draft` (paused)."
+          ],
+          "type": {
+            "kind": "booleanTypeNode",
+            "size": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFactionConfig",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionConfig",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "56d5468f71685444",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "setFactionConfigArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFactionController",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "controllerProfile",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The assignee, supplied only when setting (not clearing). Loading it as `Account<Profile>` proves it",
+            "is a real, owned `Profile` account; the handler binds its key to `new_controller`."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "2b80ff83285925f6",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "newController",
+          "docs": [
+            "The new controller profile pubkey, or `None` to clear. When `Some`, `controller_profile` MUST be",
+            "supplied and equal it (so a typo can't lock the faction behind a non-existent profile)."
+          ],
+          "type": {
+            "kind": "optionTypeNode",
+            "item": {
+              "kind": "publicKeyTypeNode"
+            },
+            "prefix": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFactionEconomicsConfig",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionEconomicsConfig",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "b1e2165ac5d58481",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "factionEconomicsDials"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFactionFlags",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "81407c124b50e41d",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "set",
+          "docs": [
+            "Bits to add."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "clear",
+          "docs": [
+            "Bits to remove."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFactionMarketStatus",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionMarket",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "acc59db12a7908bf",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "active",
+          "docs": [
+            "`true` → `Active` (tradable); `false` → `Draft` (paused)."
+          ],
+          "type": {
+            "kind": "booleanTypeNode",
+            "size": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFactionOperator",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "operatorProfileAccount",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The assignee, supplied only when setting (not clearing). Loading it as `Account<Profile>` proves it",
+            "is a real, owned `Profile` account; the handler binds its key to `operator_profile`."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "f1a47945f269119d",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "operatorProfile",
+          "docs": [
+            "The new operator profile pubkey, or `None` to clear. When `Some`, `operator_profile_account` MUST be",
+            "supplied and equal it (so a typo can't bind the faction to a non-existent operator profile)."
+          ],
+          "type": {
+            "kind": "optionTypeNode",
+            "item": {
+              "kind": "publicKeyTypeNode"
+            },
+            "prefix": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "maxNpcFleets",
+          "docs": [
+            "The hard cap on this faction's concurrent NPC fleets (the primary anti-flood brake `MintNpcFleet`",
+            "enforces unconditionally). `0` (the genesis default) disables minting entirely."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFactionRelation",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionA",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionB",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionRelationTracker",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "9e995221821e4ced",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionA",
+          "docs": [
+            "First faction id."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionB",
+          "docs": [
+            "Second faction id."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "rel",
+          "docs": [
+            "The relationship to set. `Neutral` REMOVES any existing entry on the pair."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "relationship"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "ceasefireUntil",
+          "docs": [
+            "Unix ts the ceasefire lifts (used only when `rel == Ceasefire`)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "i64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFactionRelationConfig",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionRelationTracker",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "47420bceb8da1d51",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "setFactionRelationConfigArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFactionStatus",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "82e05c48b02d3b91",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "status",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "factionStatus"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setFleetDirective",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "e93dc8774d8aa994",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "Index of the signing key on the caller's profile (admin-or-controller; validated at the LOW floor)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "docs": [
+            "The faction whose fleet is being re-tasked (seeds `faction_account`; `controller` is read from it)."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "fleet",
+          "docs": [
+            "The fleet whose FLEET-kind sidecar receives the directive (seeds `faction_ownership`)."
+          ],
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "setFleetDirectiveArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setKingSystems",
+      "docs": [
+        "Replace the canonical King-system membership and its initial effective owners. This is deliberately",
+        "admin-authored genesis/runtime data; every live ownership mutation and permissionless reconciliation",
+        "subsequently maintains the counts."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "tracker",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "ab5854e29f301213",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "systems",
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "tupleTypeNode",
+              "items": [
+                {
+                  "kind": "definedTypeLinkNode",
+                  "name": "systemId"
+                },
+                {
+                  "kind": "definedTypeLinkNode",
+                  "name": "minorFactionId"
+                }
+              ]
+            },
+            "count": {
+              "kind": "prefixedCountNode",
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              }
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "setPerkDefinitions",
+      "docs": [
+        "`SetPerkDefinitions` args — replace/extend the perk catalogue with a batch of rows."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The game account — `Mut` to append into the tail `crew_perk_definitions` map."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The Solana System program (the tail growth may need rent for the account resize)."
+          ],
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "0ca9042e5655adfe",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "the index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "defs",
+          "docs": [
+            "the perk rows to author (keyed by `id` into `Game.crew_perk_definitions`)."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "definedTypeLinkNode",
+              "name": "perkDefInput"
+            },
+            "count": {
+              "kind": "prefixedCountNode",
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              }
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "settleLoyaltyContribution",
+      "docs": [
+        "Convert one closed epoch contribution into the profile's persistent ATLAS bank exactly once."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profile",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "epoch",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "contribution",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "bank",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "config",
+          "isWritable": false,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "2aa0bed3916e620e",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "epochIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "settleMission",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "funder",
+          "isWritable": true,
+          "isSigner": true,
+          "docs": [
+            "The cranker (pays + reclaims the process rent). `recipient,funder` is REQUIRED for the",
+            "`CloseAccount` to be executable (convention #9). The ONLY signer; no `ProfileValidation`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "starbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The reserved-counter starbase-player, cross-checked by the process. `Mut` for the crew move."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "missionProcess",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The process being settled — validated against its stored `starbase_player` (the owner",
+            "cross-check) and CLOSED on success (the no-leak guarantee)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The owner's pinned reward page — CONDITIONALLY REQUIRED when the WIN branch pours XP (fail-closed)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "recentSlothashes",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The future-hash entropy source."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "missionVault",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The escrow vault, seeds re-derived from the process key (boundary-enforced). Swept + closed."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardPool",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The emissions-fed treasury — validated `== mission.reward_pool` in-handler. `Mut` for the draw + breaker."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The owner's character (WIN ATLAS reward + stake-refund target). A `CharacterSeeds{profile,game}`",
+            "PDA the cranker can supply; validated in-handler against the process owner + the game-sub pin."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "regionOrderAnchor",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The per-region sector anchor — seeds `(game, mission.region_id)` validated in-handler (region_id",
+            "comes from the process, not the caller). `Mut` for the impact fold. (CreateIfNeeded at first settle",
+            "is the alternative; v1 requires it pre-created by the admin ix.)"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "d3f6d928a49b8023",
+            "encoding": "base16"
           }
         }
       ],
@@ -21367,7 +37719,7 @@
           "isWritable": true,
           "isSigner": false,
           "docs": [
-            "The [`Fleet`](crate::state::Fleet) account"
+            "The `Fleet`(crate.state.Fleet) account"
           ]
         },
         {
@@ -21521,6 +37873,13 @@
               }
             ]
           }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -21900,6 +38259,22 @@
               }
             ]
           }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "crew: APPEND-LAST optional per-fleet binding (red-team C1/R13). Positional `Option`",
+            "crew: decode ⇒ a pre-crew client that omits this trailing account decodes it as `None`,",
+            "crew: every fold below no-ops to identity, and the instruction is byte-identical to today.",
+            "crew: Folds read `crew_binding.summary`; build #18 also AUTO-POURS Crafting XP into it once the",
+            "crew: craft commits — hence `Mut` (the append-last Option still decodes via the program-id",
+            "crew: sentinel, so Mut stays flag-off-safe). Crafting is starbase-side (no fleet account), so the",
+            "crew: resolve below locks on the OWNER profile only — the player picks which fleet's crew staffs it."
+          ]
         }
       ],
       "arguments": [
@@ -22160,6 +38535,572 @@
                 "endian": "le"
               }
             }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "startMission",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "missionProcess",
+          "isWritable": true,
+          "isSigner": true,
+          "docs": [
+            "The NEW mission process (keypair-funded, closed on terminal call) — clone of `quest_process`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The owner's character — the in-game ATLAS source (`character.atlas`, the `AtlasBalance` ledger,",
+            "per `trade.rs`). Validated against `profile_validation.profile` + `game` (PR#732 house type)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "starSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The system the starbase-player is in — asserted `== sbp.system`, read `region: Option<RegionId>`",
+            "to PIN `MissionProcess.region_id` (never caller-chosen; 10 §2.1 step 6, option a)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "missionVault",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The per-mission escrow PDA, seeds `(b\"MissionVault\", mission_process.key)`."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardPool",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The emissions-fed treasury this mission's WIN draws from — pinned into the process."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "stakeFleet",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "(v1: ATLAS-only) Reserved for a future on-chain RESOURCE stake. StartMission rejects",
+            "`stake_resource_qty > 0` in v1, so this trailing optional account is currently always omitted; it is",
+            "kept in the set for forward-compatibility once the stake-return path is designed. Validated against",
+            "game + owner profile (same arg shape scan.rs uses for its fleet); when None the validate is a no-op."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "regionTracker",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Phase-2: the region tracker — read-only, to pin the sector's RIGHTFUL incumbent",
+            "(`regions[region_id].owner`) TRUSTLESSLY at start (never a caller arg). Same validate arg shape as",
+            "scan.rs's region_tracker."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "outlawFlag",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Phase-2: the actor's OutlawFlag for `base_faction` (APPEND-LAST optional). Omitted (program-id",
+            "sentinel) ⇒ not outlaw ⇒ own-faction opposition stays BLOCKED (fail-closed). `AccountValidate`",
+            "checks the profile match; the handler re-derives the (profile, base_faction) PDA + key-checks it",
+            "(base_faction isn't known at validate). Read-only — `StartMission` only SNAPSHOTS the resolved value."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "dce029192e86fe9d",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crew",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "duration",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "i64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "rewardPage",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "rewardXp",
+          "docs": [
+            "WIDENED u8 -> u16 vs StartQuest (BUILD BLOCKER #0)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "rewardAtlas",
+          "docs": [
+            "the ATLAS (Floyds) paid on win (the catalog's tier-scaled winAtlas); breaker-capped at settle."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "successBps",
+          "docs": [
+            "THE committed success target (0..=10000), computed off-chain by `formula.js` (parity)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "sectorWinDelta",
+          "docs": [
+            "committed sector impacts (off-chain PRE-SCALED; settle folds exactly one into the RegionOrderAnchor)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "i16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "sectorLossDelta",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "i16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "missionTemplateId",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "lootTableId",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "stakeAtlas",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "stakeResourceId",
+          "docs": [
+            "0 = no resource stake. Multi-resource stakes pass extra legs as remaining_accounts (vault map)."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "cargoId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "stakeResourceQty",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "stanceSide",
+          "docs": [
+            "Phase-2 faction-stance (doc 180): 0=INCUMBENT intent, 1=CHALLENGER intent, 255=NONE (untagged).",
+            "Whether this resolves to support/oppose/treason is DERIVED at settle (stance_side × incumbent × base)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "startQuest",
+      "docs": [
+        "`StartQuest` args. Clones `ContributeToStarbaseUpgrade` (contribute_rs:22-34): the profile",
+        "`key_index`, the crew count to reserve, and the quest parameters (duration + the flat",
+        "reward). `crew` is the number reserved Busy (the engine's `num_crew`)."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "questProcess",
+          "isWritable": true,
+          "isSigner": true,
+          "docs": [
+            "The NEW quest process account (created here, closed on a terminal call). Init+Signer,",
+            "exactly as the upgrade process (contribute_rs:66-68); `Create(())` because it is a",
+            "keypair account (not a PDA) — the process's own key is its sequence id (state-slice",
+            "quest_rs note)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The Solana System program."
+          ],
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "d4b54f2cc8f20d69",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "the index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crew",
+          "docs": [
+            "the number of crew to reserve Busy for this quest (the engine's `num_crew`)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "duration",
+          "docs": [
+            "the quest duration in seconds (`end_time = now + duration`)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "i64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "rewardXp",
+          "docs": [
+            "the flat XP reward poured on completion (credited as XP toward perk-point milestones,",
+            "NOT a direct perk-point mint — PR #732 fourth review; saturated at `PERK_POINTS_MAX`)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "rewardPage",
+          "docs": [
+            "the roster page the reward must land on (PR #732 third review). The owner pins it here",
+            "(they sign `StartQuest`); `CompleteQuest` credits EXACTLY this page of the owner's",
+            "character, so a permissionless cranker can neither omit the roster nor steer the payout",
+            "to a dust page. Ignored when `reward_xp == 0`."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
           }
         }
       ],
@@ -22529,7 +39470,7 @@
           "isWritable": true,
           "isSigner": false,
           "docs": [
-            "The [`Fleet`](crate::state::Fleet) account"
+            "The `Fleet`(crate.state.Fleet) account"
           ]
         },
         {
@@ -22549,6 +39490,13 @@
           "docs": [
             "The region tracker account"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -22760,7 +39708,7 @@
           "isWritable": true,
           "isSigner": false,
           "docs": [
-            "The [`Fleet`](crate::state::Fleet) account"
+            "The `Fleet`(crate.state.Fleet) account"
           ]
         },
         {
@@ -22778,8 +39726,22 @@
           "isWritable": true,
           "isSigner": false,
           "docs": [
-            "The [`CelestialBody`] account"
+            "The `CelestialBody` account"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "regionTracker",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -22980,6 +39942,216 @@
           "type": {
             "kind": "numberTypeNode",
             "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "sweepExpiredCombatRewardLoot",
+      "docs": [
+        "Return expired, unclaimed reward-issued cargo to the global reward reserve. Ordinary carried-cargo",
+        "Loot is never swept by this instruction."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "loot",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "lootCreator",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "Original Loot creator; receives rent if all ordinary/reward items are gone."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "80cf7806156f2aa1",
+            "encoding": "base16"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "sweepExpiredLoyaltyAtlasBank",
+      "docs": [
+        "Return an expired persistent-bank balance to its faction treasury. Non-expiring banks cannot sweep."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profile",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "bank",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "a6ff135e3224b41f",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "sweepLoyaltyEpoch",
+      "docs": [
+        "Return unallocated pool dust and unsettled contributions to the same faction treasury after deadline."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "epoch",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "213ad966f3e7b77e",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "epochIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
             "endian": "le"
           }
         }
@@ -23196,6 +40368,568 @@
             "kind": "bytesValueNode",
             "data": "724dfc1b34a1029c",
             "encoding": "base16"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "tradeEncounter",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The trading fleet — crew normalized at validation; cargo is delivered to / taken from its hold."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "encounterMarket",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The player's open market (game-scoped; owner re-checked in the handler). Offer qtys decrement here."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The treasury this market settles against (bound match re-checked in the handler). Value moves here."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionStanding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The signer's `(game, profile, faction)` standing PDA (created via `InitFactionStanding`); credited here."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Per-game reputation dials (`[FactionConfig, game]`): supplies `standing_bps` + the decay/DR/cap."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionEpochMeter",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Per-faction aggregate emission meter (`[FactionEpochMeter, game, faction]`): the anti-sybil cap."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "377fd3651482658c",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "Index into the signer profile's key set (proves SCAN authority over the character/fleet)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "offerIndex",
+          "docs": [
+            "Which `LiveOffer` of the market to fill."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "quantity",
+          "docs": [
+            "Requested units. Bounded by the offer's remaining qty, then capped by stock (buy) or holdings (sell)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "playerBuys",
+          "docs": [
+            "`true` = player buys from the NPC (Ask leg); `false` = player sells to the NPC (Bid/faucet leg)."
+          ],
+          "type": {
+            "kind": "booleanTypeNode",
+            "size": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "tradeFactionMarket",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "system",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The anchoring star system; must contain a starbase (supplies the dock `seq_id` + the market's 3rd seed)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "starbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The DOCK gate — the player must have an undestroyed docked presence at this starbase (matches",
+            "`ManageLocalMarketOrder`, NOT the encounter's fleet-idle-at-sector check)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "starbasePlayer",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "5374617262617365506c61796572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "system1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "character2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "system1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "system"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "character2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "character"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The trading fleet — crew normalized at validation; cargo is delivered to / taken from its hold."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionMarket",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The faction market (game-scoped; PDA + starbase binding re-checked in the handler). Offer qtys",
+            "decrement here; the in-trade restock rewrites the list in place (same count, no realloc)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "treasury",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The faction's one treasury (PDA re-derived from the market's `faction_id`). All value moves here; a",
+            "Bid that supplies a not-yet-stocked cargo reallocs its `reserves` map (hence `NormalizeRent`, as in",
+            "`FundFactionTreasuryCargo`)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionStanding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The signer's `(game, profile, faction)` standing PDA (created via `InitFactionStanding`); read for the",
+            "access band, credited on the SELL leg."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionConfig",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Per-game reputation dials (`[FactionConfig, game]`): the decay/DR/aggregate-cap bundle."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionEpochMeter",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Per-faction aggregate emission meter (`[FactionEpochMeter, game, faction]`): the anti-sybil cap."
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "08e8ac347836961e",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "Index into the signer profile's key set (proves `MANAGE_LOCAL_MARKET_ORDERS` over the character/fleet)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "offerIndex",
+          "docs": [
+            "Which `LiveOffer` of the market to fill."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "quantity",
+          "docs": [
+            "Requested units. Bounded by the offer's remaining qty, then capped by sellable stock (buy) or",
+            "holdings (sell)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "playerBuys",
+          "docs": [
+            "`true` = player buys from the faction (Ask leg); `false` = player sells to the faction (Bid/faucet)."
+          ],
+          "type": {
+            "kind": "booleanTypeNode",
+            "size": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
           }
         }
       ],
@@ -23458,7 +41192,7 @@
         "",
         "Logic overview:",
         "- Check that the profile has MANAGE_FLEET_CARGO permissions",
-        "- Ensure that the fleet is either idle or docked",
+        "- Ensure that the fleet is either idle, docked, or in a claim stake transfer",
         "- Check that the fleet belongs to the profile and is not destroyed and has normalized crew",
         "- Transfer cargo between the selected fleet cargo pods"
       ],
@@ -23598,6 +41332,565 @@
     },
     {
       "kind": "instructionNode",
+      "name": "transferFactionOwnership",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "system",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Live StarSystem to re-witness `captured_seq_id` from (the stale-sidecar recovery lever, spec MD-P4-6).",
+            "REQUIRED for a STARBASE asset and must BE the asset's system; omit for FLEET/REGION (witness preserved).",
+            "Re-witnessing here (rather than trusting an admin-supplied seq) removes the brick-the-capture footgun."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "kingTracker",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "7da2ca27da37d2ce",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "assetKind",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "assetKey",
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "args",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "transferFactionOwnershipArgs"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "unbindCrew",
+      "docs": [
+        "`UnbindCrew` args. Identifies the crew by `crew_asset_id` (stable identity, master R-S1) —",
+        "the handler locates its index in the roster List, so a client never passes a raw index",
+        "that could race the List order."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "13778a96dc625c92",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetId",
+          "docs": [
+            "The crew cNFT asset id to unbind."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "The roster page the crew lives on."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "unequipGear",
+      "docs": [
+        "`UnequipGear` args — clear one physical slot, returning the item to escrow."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "3a21f6aaba8a3de2",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetId",
+          "docs": [
+            "The crew (by asset id) to unequip from."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "slotIdx",
+          "docs": [
+            "The physical slot index to clear (`0..GEAR_SLOTS`)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "The roster page the crew lives on."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "unloadFleetCrew",
       "docs": [
         "Unload crew from a fleet",
@@ -23711,6 +42004,461 @@
           "name": "keyIndex",
           "docs": [
             "the index of the key in the player profile"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "unloadFleetCrewRoster",
+      "docs": [
+        "`UnloadFleetCrewRoster` args — symmetric to `LoadFleetCrewRoster`."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "fleet",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The `Fleet` account (fleet_crew_rs:38-43)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review).",
+            "Validated against the signer's profile + game; a supplied roster must then BE this",
+            "character's `(character, page_index)` PDA, so loading ANOTHER player's crew into",
+            "this fleet (and stealing their bonuses into the binding) is impossible."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerSystem",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The [`StarSystem`] account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemAndStarbasePlayerStarbasePlayer",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The [`StarbasePlayer`] Account"
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The crew roster page holding the named individuated crew. Append-last optional."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "50a3bae6c214834b",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "count",
+          "docs": [
+            "passenger count (fungible quantity; fleet_crew_rs:114-119 preserved)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetIds",
+          "docs": [
+            "The specific crew (by asset id) to flip `OnFleet → AtStarbase`. Empty ⇒ fungible-only."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            },
+            "count": {
+              "kind": "prefixedCountNode",
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              }
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "the roster page the named crew live on."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "the index of the key in the player profile."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "unlockPerk",
+      "docs": [
+        "`UnlockPerk` args — slot one perk on one crew at a tier."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "The game account — both the `crew_config` flag gate AND the `crew_perk_definitions`",
+            "catalogue the perk id resolves against."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "character",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The caller's `Character` — the crew-roster OWNER anchor (PR #732 second review)."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "character",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "436861726163746572",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "profileValidationProfile1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game2",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "profileValidationProfile1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "profileValidationProfile"
+                }
+              },
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game2",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "roster",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "e388cd5af9df3431",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "crewAssetId",
+          "docs": [
+            "The crew (by asset id) to unlock the perk on."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "perkId",
+          "docs": [
+            "The catalogue perk id (key into `Game.crew_perk_definitions`; `0` rejected)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "tier",
+          "docs": [
+            "The tier to slot the perk at (`>= 1`; magnitude is `mag_per_tier × tier`)."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "pageIndex",
+          "docs": [
+            "The roster page the crew lives on."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile."
           ],
           "type": {
             "kind": "numberTypeNode",
@@ -23984,6 +42732,160 @@
           "type": {
             "kind": "definedTypeLinkNode",
             "name": "researchNodeId"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "updateAtlasRewardConfig",
+      "docs": [
+        "Create a new immutable config version from a partial patch and activate it next epoch."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "registry",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "baseConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "newConfig",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "55d6be2cab05d9ce",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "baseConfigVersion",
+          "docs": [
+            "Must be the active config, or the pending config when revising an update before activation."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "newConfigVersion",
+          "docs": [
+            "Must equal `registry.latest_config_version + 1`."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "allowOutstandingMedallionReprice",
+          "docs": [
+            "Explicitly accept repricing every outstanding token when the medallion cargo id is unchanged."
+          ],
+          "type": {
+            "kind": "booleanTypeNode",
+            "size": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "partial",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "atlasRewardConfigPartial"
           }
         }
       ],
@@ -24599,6 +43501,121 @@
     },
     {
       "kind": "instructionNode",
+      "name": "updateCombatStimulantDefinition",
+      "docs": [
+        "Creates or replaces a combat stimulant definition on the Game config."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": true,
+          "isSigner": false
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "48457151ffb9cdf2",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "docs": [
+            "The index of the key in the player profile"
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "stimCargoId",
+          "docs": [
+            "Cargo id of the stimulant item this definition describes."
+          ],
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "cargoId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "effects",
+          "docs": [
+            "One to three effects applied when this stimulant is consumed."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "definedTypeLinkNode",
+              "name": "stimEffect"
+            },
+            "count": {
+              "kind": "prefixedCountNode",
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              }
+            }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "updateCraftingHabDefinition",
       "docs": [
         "Input data for updating a crafting hab definition"
@@ -24826,6 +43843,147 @@
               "format": "u8",
               "endian": "le"
             }
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
+      "name": "updateFaction",
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionAccount",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "systemProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "11111111111111111111111111111111"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "aafbf3e0da7a3714",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "nameHash",
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "contentUriHash",
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "homeRegion",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "regionId"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "maxAllies",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
           }
         }
       ],
@@ -25341,11 +44499,11 @@
         "performs authorization checks, ensures the region exists, and updates only the",
         "properties that are explicitly provided in the instruction arguments.",
         "",
-        "The update can modify any combination of: owner faction, safety status, border,",
-        "connections, research requirements, and core systems. Any field not provided",
-        "will remain unchanged. When the border changes, it is snapped to the tracker's grid",
-        "(`grid_k`) and adjacency (`neighbors_by_edge`) is rebuilt. When connections change,",
-        "safety status is updated accordingly.",
+        "The update can modify any combination of: authored risk tier, border, connections,",
+        "research requirements, and XP modifier. Any field not provided will remain unchanged.",
+        "When the border changes, it is snapped to the tracker's grid",
+        "(`grid_k`) and geometric adjacency (`neighbors_by_edge`) is rebuilt. Dynamic safety",
+        "and effective risk are derived from that geometric adjacency, not `connections`.",
         "",
         "# Fields",
         "* `id` - Unique identifier for the region to update",
@@ -26034,6 +45192,31 @@
         },
         {
           "kind": "instructionAccountNode",
+          "name": "rewardRegistry",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "rewardConfig",
+          "isWritable": false,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "kingTracker",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionOwnership",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
           "name": "systemProgram",
           "isWritable": false,
           "isSigner": false,
@@ -26287,6 +45470,96 @@
     },
     {
       "kind": "instructionNode",
+      "name": "updateXpRenownConfig",
+      "docs": [
+        "Updates Council Rank renown generation config for a game."
+      ],
+      "accounts": [
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationSigner",
+          "isWritable": false,
+          "isSigner": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProfile",
+          "isWritable": true,
+          "isSigner": false
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationCertificate",
+          "isWritable": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "profileValidationProgram",
+          "isWritable": false,
+          "isSigner": false,
+          "defaultValue": {
+            "kind": "publicKeyValueNode",
+            "publicKey": "C4PRoFNroxxzdgeCoM31LJjYRg7kT6ymogSTAT99iD1u"
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "game",
+          "isWritable": true,
+          "isSigner": false,
+          "docs": [
+            "The game account to be updated"
+          ]
+        }
+      ],
+      "arguments": [
+        {
+          "kind": "instructionArgumentNode",
+          "name": "discriminator",
+          "defaultValueStrategy": "omitted",
+          "type": {
+            "kind": "fixedSizeTypeNode",
+            "size": 8,
+            "type": {
+              "kind": "bytesTypeNode"
+            }
+          },
+          "defaultValue": {
+            "kind": "bytesValueNode",
+            "data": "af6806c057e5b11d",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "keyIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "instructionArgumentNode",
+          "name": "config",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "renownConfig"
+          }
+        }
+      ],
+      "discriminators": [
+        {
+          "kind": "fieldDiscriminatorNode",
+          "name": "discriminator",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "kind": "instructionNode",
       "name": "updateXpThresholds",
       "docs": [
         "Updates the xp thresholds for a game.",
@@ -26434,7 +45707,8 @@
         "- Calculate warp lane distance, duration & expected fuel expenditure",
         "- Check that the warp lane movement will not terminate in an enemy safe zone",
         "- Consume fuel",
-        "- Start the warp lane movement"
+        "- Start the warp lane movement",
+        "- Award distance-based Pilot XP through the Character's shared movement budget"
       ],
       "accounts": [
         {
@@ -26551,7 +45825,8 @@
           "isWritable": false,
           "isSigner": false,
           "docs": [
-            "The fleet`s current StarSystem"
+            "The fleet`s current StarSystem. P3.5: game-scoped only (NOT faction-pinned) so cross-faction lanes",
+            "can be passed; the faction/toll decision moves to `process()` behind `cross_faction_economics_enabled`."
           ]
         },
         {
@@ -26560,7 +45835,7 @@
           "isWritable": false,
           "isSigner": false,
           "docs": [
-            "The StarSystem that `Fleet` will move to"
+            "The StarSystem that `Fleet` will move to (game-scoped; see `from_system`)."
           ]
         },
         {
@@ -26585,6 +45860,63 @@
                   "value": {
                     "kind": "bytesValueNode",
                     "data": "43757272656e6379436f6e666967",
+                    "encoding": "base16"
+                  }
+                },
+                {
+                  "kind": "variablePdaSeedNode",
+                  "name": "game1",
+                  "type": {
+                    "kind": "publicKeyTypeNode"
+                  }
+                }
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "pdaSeedValueNode",
+                "name": "game1",
+                "value": {
+                  "kind": "accountValueNode",
+                  "name": "game"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "factionRelationTracker",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "P3.5 cross-faction warp economics: the per-game relation tracker — the",
+            "`cross_faction_economics_enabled` flag, the toll dials, and the relationship lookup. REQUIRED: when",
+            "the flag is `0`, cross-faction warp is foreclosed exactly as pre-P3.5 (same-faction warp is unaffected)."
+          ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "regionTracker",
+          "isWritable": false,
+          "isSigner": false,
+          "docs": [
+            "Region graph used to enforce the destination's effective risk tier."
+          ],
+          "defaultValue": {
+            "kind": "pdaValueNode",
+            "pda": {
+              "kind": "pdaNode",
+              "name": "regionTracker",
+              "seeds": [
+                {
+                  "kind": "constantPdaSeedNode",
+                  "type": {
+                    "kind": "bytesTypeNode"
+                  },
+                  "value": {
+                    "kind": "bytesValueNode",
+                    "data": "526567696f6e547261636b6572",
                     "encoding": "base16"
                   }
                 },
@@ -26664,7 +45996,8 @@
         "- Check that the warp distance is within the fleet's warp range",
         "- Set new warp cool down time",
         "- Consume fuel",
-        "- Start the warp movement"
+        "- Start the warp movement",
+        "- Award distance-based Pilot XP through the Character's shared movement budget"
       ],
       "accounts": [
         {
@@ -26763,7 +46096,7 @@
           "isWritable": true,
           "isSigner": false,
           "docs": [
-            "The [`Fleet`](crate::state::Fleet) account"
+            "The `Fleet`(crate.state.Fleet) account"
           ]
         },
         {
@@ -26783,6 +46116,13 @@
           "docs": [
             "The region tracker account"
           ]
+        },
+        {
+          "kind": "instructionAccountNode",
+          "name": "crewBinding",
+          "isWritable": true,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "arguments": [
@@ -27284,6 +46624,41 @@
   "definedTypes": [
     {
       "kind": "definedTypeNode",
+      "name": "activeStimulant",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stat",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "combatStatField"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "deltaBps",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "chargesRemaining",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "addShipArgs",
       "type": {
         "kind": "structTypeNode",
@@ -27440,6 +46815,544 @@
               "kind": "numberTypeNode",
               "format": "u64",
               "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "atlasRewardConfigInitValues",
+      "docs": [
+        "Compact bootstrap values for `InitAtlasRewardConfig`.",
+        "",
+        "A full config with all three variable-length tables can exceed Solana's transaction-size ceiling.",
+        "Initialization therefore installs the default King curve with empty material/salvage tables and all",
+        "sources disabled. Admins populate each table through one or more partial updates before enabling the",
+        "final pending version."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochLenSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "claimSettlementWindowSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasBankInactivityExpirySecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardLootReclaimSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionPoolLever",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pveLpRateBps",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pvpMedallionRateBps",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "salvageEvRateBps",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "repairKitLpRate",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lossModelTargetBps",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u16",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 3
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "starbaseDestructionMedallions",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 7
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "activeMedallion",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "medallionRewardConfig"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "medallionBuybackCapPerEpoch",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardReserveLowBalanceThreshold",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "atlasRewardConfigPartial",
+      "docs": [
+        "Partial runtime update. Every authored value in [`AtlasRewardConfigValues`] is represented."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "enabled",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "booleanTypeNode",
+                "size": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                }
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "sourceFlags",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u16",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochLenSecs",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "claimSettlementWindowSecs",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasBankInactivityExpirySecs",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardLootReclaimSecs",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionPoolLever",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "kingSystemCurve",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "numberTypeNode",
+                  "format": "u64",
+                  "endian": "le"
+                },
+                "count": {
+                  "kind": "prefixedCountNode",
+                  "prefix": {
+                    "kind": "numberTypeNode",
+                    "format": "u32",
+                    "endian": "le"
+                  }
+                }
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pveLpRateBps",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pvpMedallionRateBps",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "salvageEvRateBps",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "upgradeLpRates",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "definedTypeLinkNode",
+                  "name": "upgradeLpRate"
+                },
+                "count": {
+                  "kind": "prefixedCountNode",
+                  "prefix": {
+                    "kind": "numberTypeNode",
+                    "format": "u32",
+                    "endian": "le"
+                  }
+                }
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "repairKitLpRate",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lossModelTargetBps",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "numberTypeNode",
+                  "format": "u16",
+                  "endian": "le"
+                },
+                "count": {
+                  "kind": "fixedCountNode",
+                  "value": 3
+                }
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "starbaseDestructionMedallions",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "numberTypeNode",
+                  "format": "u64",
+                  "endian": "le"
+                },
+                "count": {
+                  "kind": "fixedCountNode",
+                  "value": 7
+                }
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "activeMedallion",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "medallionRewardConfig"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "salvageEntries",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "definedTypeLinkNode",
+                  "name": "salvageRewardEntry"
+                },
+                "count": {
+                  "kind": "prefixedCountNode",
+                  "prefix": {
+                    "kind": "numberTypeNode",
+                    "format": "u32",
+                    "endian": "le"
+                  }
+                }
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "medallionBuybackCapPerEpoch",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rewardReserveLowBalanceThreshold",
+            "type": {
+              "kind": "optionTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
             }
           }
         ]
@@ -27690,7 +47603,7 @@
             "kind": "structFieldTypeNode",
             "name": "researchRequirements",
             "docs": [
-              "Research requirements (any one required)"
+              "Research requirements (all required)"
             ],
             "type": {
               "kind": "setTypeNode",
@@ -29341,6 +49254,30 @@
           },
           {
             "kind": "structFieldTypeNode",
+            "name": "scanPowerModifier",
+            "docs": [
+              "Data Runner research multiplier for scan loot. Base 1.0, additive combine."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "scanCoolDownModifier",
+            "docs": [
+              "Data Runner research multiplier for scan cooldown. Base 1.0, additive combine."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
             "name": "researchTags",
             "type": {
               "kind": "setTypeNode",
@@ -29652,6 +49589,30 @@
               "kind": "definedTypeLinkNode",
               "name": "sizeClass"
             }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "scanPowerModifier",
+            "docs": [
+              "Data Runner research multiplier for scan loot. Base 1.0, additive combine."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "scanCoolDownModifier",
+            "docs": [
+              "Data Runner research multiplier for scan cooldown. Base 1.0, additive combine."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
           }
         ]
       }
@@ -29697,6 +49658,33 @@
               "item": {
                 "kind": "definedTypeLinkNode",
                 "name": "researchNodeId"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "nodeLevels",
+            "docs": [
+              "Per-node unlock level. Missing entries for legacy/unrepeatable nodes are treated as level 1 when unlocked."
+            ],
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "researchNodeId"
+              },
+              "value": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
               },
               "count": {
                 "kind": "prefixedCountNode",
@@ -30645,6 +50633,58 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "combatRewardLeg",
+      "docs": [
+        "One destroyed player fleet's deterministic recipient and authored reward amounts. The future hash",
+        "chooses only the salvage table outcome; it cannot change the recipient or economic target."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "recipient",
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "medallions",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "salvageTargetValue",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "combatStatField",
+      "type": {
+        "kind": "tupleTypeNode",
+        "items": [
+          {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "combatStats",
       "docs": [
         "A ship's combat stats"
@@ -30809,6 +50849,499 @@
             "type": {
               "kind": "numberTypeNode",
               "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageKinetic",
+            "docs": [
+              "Kinetic damage dealt by this ship."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageKineticVariance",
+            "docs": [
+              "Kinetic damage randomization range, expressed as a multiplier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageEnergy",
+            "docs": [
+              "Energy damage dealt by this ship."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageEnergyVariance",
+            "docs": [
+              "Energy damage randomization range, expressed as a multiplier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageEmp",
+            "docs": [
+              "EMP damage dealt by this ship."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageEmpVariance",
+            "docs": [
+              "EMP damage randomization range, expressed as a multiplier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageSuperchill",
+            "docs": [
+              "Superchill damage dealt by this ship."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageSuperchillVariance",
+            "docs": [
+              "Superchill damage randomization range, expressed as a multiplier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageShockwave",
+            "docs": [
+              "Shockwave damage dealt by this ship."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageShockwaveVariance",
+            "docs": [
+              "Shockwave damage randomization range, expressed as a multiplier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageGraygoo",
+            "docs": [
+              "Gray goo damage dealt by this ship."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageGraygooVariance",
+            "docs": [
+              "Gray goo damage randomization range, expressed as a multiplier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageHeat",
+            "docs": [
+              "Heat damage dealt by this ship."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageHeatVariance",
+            "docs": [
+              "Heat damage randomization range, expressed as a multiplier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageBomb",
+            "docs": [
+              "Bomb damage dealt by this ship."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "damageBombVariance",
+            "docs": [
+              "Bomb damage randomization range, expressed as a multiplier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "counterDecoy",
+            "docs": [
+              "Decoy countermeasure strength."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "counterEnergyCapacitor",
+            "docs": [
+              "Energy capacitor countermeasure strength."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "counterFireSuppressor",
+            "docs": [
+              "Fire suppressor countermeasure strength."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "counterFlare",
+            "docs": [
+              "Flare countermeasure strength."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "counterHealingNanobots",
+            "docs": [
+              "Healing nanobots countermeasure strength."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "counterMine",
+            "docs": [
+              "Mine countermeasure strength."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "counterNegativeRemPlating",
+            "docs": [
+              "Negative REM plating countermeasure strength."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "counterWarmingPlates",
+            "docs": [
+              "Warming plates countermeasure strength."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "counterFaradayShielding",
+            "docs": [
+              "Faraday shielding countermeasure strength."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stealthPower",
+            "docs": [
+              "Stealth strength used by combat hit/dodge calculations."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "hitChance",
+            "docs": [
+              "Hit chance modifier used by combat hit calculations."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "aimAbility",
+            "docs": [
+              "Aim ability used to offset size mismatch penalties."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "critChance",
+            "docs": [
+              "Critical hit chance."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "critMultiplier",
+            "docs": [
+              "Critical hit damage multiplier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "fuelConsumptionRate",
+            "docs": [
+              "Combat fuel consumption modifier reserved for Combat v2 balancing."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "missileDamage",
+            "docs": [
+              "Missile damage reserved for Combat v2 balancing."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "missileFireRate",
+            "docs": [
+              "Missile fire rate reserved for Combat v2 balancing."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "condPerkEntry",
+      "docs": [
+        "One conditional perk pre-loaded into the summary's `perk_cond[8]` table; a consumer",
+        "evaluates its `trigger` in a ≤8-iteration loop (master §3.4; reference-impl",
+        "`CondPerkEntry`, record_rs:320-327).",
+        "",
+        "Byte-exact to `layout.CondPerkEntryPod` (record_rs:566-577):",
+        "`perk_id(2) + slot_family(1) + trigger(1) + mag(2) + tier(1) + _pad(1) = 8 B`.",
+        "",
+        "`mag` is stored as an **`i16` q-format fixed-point delta** (NOT `f64` — the",
+        "reference-impl models it as `f64` only in its behavioral mirror; the byte-exact",
+        "proof and the real program store the raw `i16`, record_rs:319,573). The fold site",
+        "reconstitutes it into the engine's fixed-point (`PreciseStatVal`) when it sums —",
+        "the q-format scale + the fold are owned by `folds/`, not by this value object.",
+        "`slot_family` / `trigger` are raw discriminant bytes (decode via",
+        "`SlotFamily::from_u8` / `Trigger::from_u8`), kept as `u8` to preserve Pod-ness."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "perkId",
+            "docs": [
+              "On-chain perk definition id (`0` ⇒ unused table slot)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "slotFamily",
+            "docs": [
+              "Raw `SlotFamily` discriminant the perk modifies."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "trigger",
+            "docs": [
+              "Raw `Trigger` discriminant gating the perk."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "mag",
+            "docs": [
+              "Magnitude as an `i16` q-format delta (scale owned by `folds/`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "tier",
+            "docs": [
+              "Perk tier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad",
+            "docs": [
+              "Padding to the 8-byte slot (`layout.CondPerkEntryPod._pad`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
               "endian": "le"
             }
           }
@@ -31425,6 +51958,288 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "createEncounterTreasuryArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochLenSecs",
+            "docs": [
+              "Circuit-breaker epoch length, seconds. The per-epoch ATLAS-out cap resets each window."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasOutCapPerEpoch",
+            "docs": [
+              "Max ATLAS the treasury may emit on the faucet leg per epoch (inflation ceiling)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "createFactionArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "capabilityFlags",
+            "docs": [
+              "Capability bitset ([`crate::state::FactionCapabilityFlags`]). Admin-masked via `validate_flag_grant`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "nameHash",
+            "docs": [
+              "Content-addressed off-chain lore hash (SHA-256 of the canonical content file)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "contentUriHash",
+            "docs": [
+              "Off-chain manifest hash (cosmetics / blueprint catalog / dialogue)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "homeRegion",
+            "docs": [
+              "Homeland region (`0` = none)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "regionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "maxAllies",
+            "docs": [
+              "Max simultaneous Allied edges (diplomacy cap, enforced in P3)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "createFactionMarketArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minStandingBuy",
+            "docs": [
+              "Access band to BUY (Ask): standing threshold; `<= -1000` = open."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minStandingSell",
+            "docs": [
+              "Access band to SELL (faucet): `<= -1000` = open (a Hostile player can still sell their way back)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "priceTierBps",
+            "docs": [
+              "Per-depletion-tier Ask price multiplier (bps); index 0 = full stock, rising as the reserve depletes."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u16",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 4
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "authoredTargetQty",
+            "docs": [
+              "Per-offer restock target (opportunistic in-trade restock tops `remaining_qty` toward this)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "restockPeriodSecs",
+            "docs": [
+              "In-trade restock time-gate (seconds)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasBurnBps",
+            "docs": [
+              "ATLAS-burn on the faucet (sell-back) leg, basis points."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standingBps",
+            "docs": [
+              "Per-market standing accrual rate (sell-leg); `0` disables earning here."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "faucetEnabled",
+            "docs": [
+              "`0` = sell-only (faucet disabled)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "offers",
+            "docs": [
+              "The concrete offers (Ask via SIDE_SELL, Bid via SIDE_BUY). Non-empty; at most one Ask per cargo."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "liveOffer"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "createFactionTreasuryArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "epochLenSecs",
+            "docs": [
+              "Circuit-breaker epoch length, seconds. The per-epoch faucet ATLAS-out cap resets each window."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasOutCapPerEpoch",
+            "docs": [
+              "Max ATLAS the treasury may emit on the faucet (sell-back) leg per epoch."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "createRecipeInputData",
       "type": {
         "kind": "structTypeNode",
@@ -31733,6 +52548,615 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "crewMigrateInput",
+      "docs": [
+        "One crew to individuate: its DAS-attested rarity + the rarity-derived base-stat seed.",
+        "",
+        "`BorshSerialize/Deserialize + TypeToIdl` — the EXACT derive set of the existing",
+        "`CrewTransferInput` (crew_transfer_common_rs:129-134), so this rides the same client/IDL",
+        "surface. (In the full instruction the migrate item would also carry the Bubblegum",
+        "transfer proof fields of `CrewTransferInput`; this slice models the crew-record half —",
+        "the rarity attestation that seeds the on-chain `CrewRecord`. The integrator unions this",
+        "with `CrewTransferInput`'s proof fields.)"
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "crewAssetId",
+            "docs": [
+              "The crew cNFT asset id (Bubblegum leaf) — the stable per-crew identity (master R-S1)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rarity",
+            "docs": [
+              "DAS-attested rarity discriminant (`0..=5`); decoded via `Rarity::from_u8`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "baseStat",
+            "docs": [
+              "Rarity-derived base aptitude magnitude seeding every aptitude (reference-impl",
+              "`rarity_base_stat`, record_rs:398-407). Supplied (not recomputed) so the rarity→seed",
+              "ladder stays owned by the contract slice (single source of truth)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "crewRecord",
+      "docs": [
+        "One individuated crew member — the on-chain character sheet (**292 B** with the per-skill-XP",
+        "block; **202 B** through the original `tail`).",
+        "",
+        "The original blocks (identity/scalars = 40, timestamps/counters = 40, assignment = 33,",
+        "stats = 24, personality = 5, perks = 16, gear = 40, tail = 4) sum to 202 and remain",
+        "byte-exact to `crew-mechanics-detail.md` §1.2 / reference-impl `layout.CrewRecordPod`",
+        "(record_rs:530-561). **Per-skill XP (build #17)** appends a per-category XP block AT THE TAIL",
+        "(after `_pad1`, so every offset ≤ 200 is unchanged): `xp_by_category[5]` (40),",
+        "`level_by_category[5]` (10), `xp_realized_by_category[5]` (40) = 90 B ⇒ **292 B** total.",
+        "",
+        "## Per-category XP (a crew gets better at what it DOES)",
+        "The legacy `xp`/`level`/`xp_realized_at` fields (offsets 64/48/68) are PRESERVED as the",
+        "**lifetime total** (Σ category xp / level off the total) for back-compat with the decoders.",
+        "The new `*_by_category` arrays carry the per-activity tracks indexed by",
+        "`CrewXpCategory`(crate.state.CrewXpCategory) — `xp_by_category[Mining]` etc. A crew",
+        "onboarded to a mining fleet accrues `Mining` XP and levels `Mining`; one that fights accrues",
+        "`Combat`. The accrual reuses the §S.4 O(1) reward-per-share scheme PER CATEGORY (the summary's",
+        "`xp_accumulator_by_category[N]` high-water mark + these per-category `xp_realized_by_category`",
+        "low-water snapshots); see `crate.folds.xp`.",
+        "",
+        "Stored fixed-point: none in the record itself — the `i16` q-format slot deltas live",
+        "in the summary's `perk_uncond`/`gear_scalar`/`perk_cond` (see `super.RosterSummary`);",
+        "the record carries only raw magnitudes (`stats.apt` `u16`), the gear/perk sentinels,",
+        "and the XP counters (`u64`). `PreciseStatVal` is used at the FOLD site, never stored here."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "crewAssetId",
+            "docs": [
+              "The crew cNFT asset id (Bubblegum leaf) — the stable per-crew identity."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 32
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rarity",
+            "docs": [
+              "Raw `Rarity` discriminant (`0..=5`); decode via `Rarity.from_u8`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "level",
+            "docs": [
+              "Crew level, `1..=CREW_LEVEL_MAX` (`u16` — contract-change request #2). Occupies",
+              "the 2 bytes the reference proof reserves as `level: u8 + _lvl_hi: u8`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "perkCount",
+            "docs": [
+              "Number of perk slots filled (`0..=PERK_SLOT_CAP`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "perkPointsSpent",
+            "docs": [
+              "Perk points already spent (`0..=PERK_POINTS_MAX`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "schemaVersion",
+            "docs": [
+              "**Round-trip serialization schema version** for the cross-chain crew bridge",
+              "(entry-seed attestation -> `CrewRecord`, and `CrewRecord` -> galaxy on exit-settle;",
+              "cuniculture review, PR #732). `0` = the canonical encoding this PR freezes (field order +",
+              "`I72F56` fixed-point rendering specified in the crew bridge design doc). Carved from the",
+              "FIRST byte of the reference proof's 3-byte `_pad0` (zero-default ⇒ byte-identical to the",
+              "pre-this-change image — the `reward_page` pad-reuse technique), so the deterministic",
+              "`CrewRecord`->galaxy projection can be re-versioned WITHOUT a record-layout migration once",
+              "z.ink rosters are live. The roster account also carries a page-level",
+              "`super.RosterSummary.version`; this per-record byte versions the per-crew snapshot that",
+              "exits escrow independently. A bumped `schema_version` selects a newer",
+              "`(serialize, deserialize)` pair; never reinterpret an old record under a new schema."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "docs": [
+              "Alignment pad to the 40-byte identity block (the back 2 bytes of the reference proof's",
+              "`layout.CrewRecordPod._pad0`, after the `schema_version` byte carved from its head)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "boundAt",
+            "docs": [
+              "Unix ts the crew was bound to this roster."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "busyUntil",
+            "docs": [
+              "Unix ts a `Busy` crew becomes free again (`0` when not busy)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastFireEpoch",
+            "docs": [
+              "Last combat epoch this crew fired (respawn/cooldown accounting)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "xp",
+            "docs": [
+              "Accumulated XP."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "xpRealizedAt",
+            "docs": [
+              "Snapshot of the fleet per-capita XP accumulator at last realize (master §S.4) —",
+              "the lazy-XP low-water mark."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "assignment",
+            "docs": [
+              "Current assignment (`CrewStatus`: tag + optional fleet key)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "crewStatus"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stats",
+            "docs": [
+              "9 aptitude magnitudes + 3 tag bitmasks (`CrewStats`)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "crewStats"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bigFive",
+            "docs": [
+              "Big-five personality bytes (q0.8 fixed-point). Offer-gate / cosmetic ONLY —",
+              "never a magnitude input (master §3.2)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 5
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "perks",
+            "docs": [
+              "Unlocked perk slots; `perk_id == 0` ⇒ empty (`[PerkSlot; PERK_SLOT_CAP]`)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "perkSlot"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 4
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gear",
+            "docs": [
+              "Equipped gear; `gear_id == 0` ⇒ empty (`[GearRef; GEAR_SLOTS]`, sentinel —",
+              "contract-change request #1)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "gearRef"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 5
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rented",
+            "docs": [
+              "`1` ⇒ this crew is rented (economy lane; reference-impl `rented`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "bump",
+            "docs": [
+              "PDA bump if this record is the inline crew of a `super.CrewMember` (Officer v1);",
+              "`0` for List-roster records."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad1",
+            "docs": [
+              "Tail pad to the original 202-byte boundary (`layout.CrewRecordPod._pad1`). The per-skill",
+              "XP block below is appended AFTER this, so offsets ≤ 200 stay byte-identical to pre-#17."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "xpByCategory",
+            "docs": [
+              "Per-activity XP, indexed by `CrewXpCategory`(crate.state.CrewXpCategory)",
+              "(`xp_by_category[Mining]` etc.). The lifetime total stays in `xp` (off 64)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 5
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "levelByCategory",
+            "docs": [
+              "Per-activity level (`1..=CREW_LEVEL_MAX`), indexed by `CrewXpCategory`. Derived from",
+              "`xp_by_category` via `crate.folds.xp.expected_level`. The lifetime total level stays",
+              "in `level` (off 33). A fresh crew is level `1` in every category."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u16",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 5
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "xpRealizedByCategory",
+            "docs": [
+              "Per-activity snapshot of the matching `RosterSummary::xp_accumulator_by_category[cat]` at",
+              "last realize — the per-category lazy-XP low-water mark (the §S.4 reward-per-share scheme,",
+              "one stream per category). Snapshotted to the fleet's per-category accumulator on load so a",
+              "crew earns each category only from join-time on; advanced on every realize."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 5
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "assignedShipId",
+            "docs": [
+              "The ship MODEL this crew is posted to within its fleet (`ShipId` raw value), `0` =",
+              "fleet pool / no posting (the pre-posting behavior). C4 fleets track ship models +",
+              "counts (`Fleet.fleet_ships`), not individual hulls, so a posting targets a model slot.",
+              "Set by `LoadFleetCrewRoster` (validated against `Game.ship_definitions` and the fleet's",
+              "own composition), cleared on unload. Only meaningful while `assignment` is `OnFleet`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "assignedShipWeight",
+            "docs": [
+              "SNAPSHOT of the posting's ship weight at load time (`max(1, ship.stats.misc_stats",
+              ".required_crew)` — bigger ships' specialists weigh more in the fleet average). `0` =",
+              "no posting ⇒ the census treats the weight as `1` (exactly the pre-posting math). A",
+              "snapshot so unload reverses the identical quantity even if definitions later change."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "crewStats",
+      "docs": [
+        "9 aptitude magnitudes + 3 independent tag bitmasks. A crew can be major/anomalous",
+        "on several aptitudes at once — the **breadth** axis (master §5.1; reference-impl",
+        "`CrewStats`, record_rs:231-282).",
+        "",
+        "Byte-exact to `layout.CrewStatsPod` (record_rs:518-527):",
+        "9 aptitude `u16` (18) + 3 mask `u16` (6) = 24 B. Index order of `apt[9]` matches the",
+        "`Aptitude` discriminants and `RosterSummary.sum_apt[9]`."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "apt",
+            "docs": [
+              "Per-aptitude magnitude, indexed by `Aptitude.as_idx`."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u16",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 9
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minorMask",
+            "docs": [
+              "Bit `i` set ⇒ aptitude `i` is tagged `Minor`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "majorMask",
+            "docs": [
+              "Bit `i` set ⇒ aptitude `i` is tagged `Major`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "anomalousMask",
+            "docs": [
+              "Bit `i` set ⇒ aptitude `i` is tagged `Anomalous`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "crewStatus",
+      "docs": [
+        "One crew member's assignment: a 33-byte Pod value `{ tag: u8, target: OptionalKeyFor<Fleet> }`.",
+        "",
+        "Byte-exact to the reference-impl `layout.CrewStatusPod` (record_rs:486-494):",
+        "`tag(1) + target(32) = 33`. `OptionalKeyFor<Fleet>` is `#[repr(transparent)]` over a",
+        "`Pubkey` (32 B), `Align1` + `Pod`, with a `NONE` sentinel of all-zero bytes",
+        "(ref star_frame/star_frame/src/data_types/optional_key_for_rs:22-48,159-173) — so the",
+        "whole struct is `Align1` Pod with no padding, List-able inside `CrewRecord`.",
+        "",
+        "`tag` is stored raw (see module note); use `Self.tag`/`Self.set_tag` for the",
+        "typed `CrewStatusTag` view. `target` is meaningful only when `tag == OnFleet`;",
+        "it is `OptionalKeyFor::<Fleet>::NONE` in every other state."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "tag",
+            "docs": [
+              "Raw `CrewStatusTag` discriminant. Kept as `u8` to preserve `CrewRecord`'s",
+              "`Pod`-ness (a `Pod` struct cannot contain a non-`Pod` enum field)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "target",
+            "docs": [
+              "The assigned `Fleet`, or `OptionalKeyFor::NONE` (all-zero) when not `OnFleet`.",
+              "`Fleet` is `#[unsized_type(program_account, seeds = FleetSeeds)]` (`?Sized`);",
+              "`OptionalKeyFor<T: ?Sized>` supports unsized targets",
+              "(ref sage/src/state/hangar/fleet/mod_rs:56-57)."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "crewTransferInput",
       "type": {
         "kind": "structTypeNode",
@@ -32017,6 +53441,135 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "factionEconomicsDials",
+      "docs": [
+        "The 4 tunable dials (shared by `Init` + `Set`)."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "npcMintCostAtlas",
+            "docs": [
+              "ATLAS debited from the minting faction's treasury per `MintNpcFleet` (`0` = free, test only)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "npcRespawnCostAtlas",
+            "docs": [
+              "ATLAS debited per NPC fleet respawn (the churn brake)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "captureCostAtlas",
+            "docs": [
+              "ATLAS debited from the captor faction's treasury per dynamic starbase capture (`0` = no cost)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "factionCaptureCooldownSecs",
+            "docs": [
+              "Per-faction anti-blitz capture cooldown (secs)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "factionPair",
+      "docs": [
+        "Canonical unordered faction-pair key (`lo <= hi`, so `(a,b)` and `(b,a)` map to ONE entry). `Pod` packed,",
+        "align 1, 4 B. As a `Map` key it MUST derive `Ord`/`PartialOrd` (mirrors `define_id_struct!` + `BoundingBox`)."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lo",
+            "docs": [
+              "The numerically-smaller faction id."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "hi",
+            "docs": [
+              "The numerically-larger faction id."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "factionStatus",
+      "docs": [
+        "Lifecycle status of a dynamic faction. Mirrors [`ScanPatternStatus`](crate::state::ScanPatternStatus)",
+        "(`Draft`/`Active`) plus a terminal `Retired` (soft-retire: the PDA is never closed/reused, since",
+        "`faction_id` may be a historical owner/controller)."
+      ],
+      "type": {
+        "kind": "enumTypeNode",
+        "variants": [
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "draft",
+            "discriminator": 0
+          },
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "active",
+            "discriminator": 1
+          },
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "retired",
+            "discriminator": 2
+          }
+        ],
+        "size": {
+          "kind": "numberTypeNode",
+          "format": "u8",
+          "endian": "le"
+        }
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "fleetCargoHoldInput",
       "type": {
         "kind": "structTypeNode",
@@ -32262,6 +53815,91 @@
           "format": "u8",
           "endian": "le"
         }
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "gearRef",
+      "docs": [
+        "One equipped gear reference. **Sentinel, not `Option`**: `gear_id == 0` means",
+        "\"empty slot\" (contract-change request #1 — `Option<T>` is not a Star Frame `Pod`,",
+        "so it can never be a field of the Pod `CrewRecord`; the reference-impl models the",
+        "same sentinel, record_rs:284-302).",
+        "",
+        "Byte-exact to `layout.GearRefPod` (record_rs:496-506):",
+        "`gear_id(2) + tier(1) + _pad(1) + durability(2) + _pad2(2) = 8 B`."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gearId",
+            "docs": [
+              "On-chain gear definition id. `0` ⇒ empty slot (the sentinel)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "tier",
+            "docs": [
+              "Gear tier (recipe tier; `gear_rs` owns recipe/sink semantics)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad",
+            "docs": [
+              "Padding to keep the byte image identical to `layout.GearRefPod._pad`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "durability",
+            "docs": [
+              "Remaining durability (sink-eroded; faucet-ledgered in `gear_rs`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad2",
+            "docs": [
+              "Padding to pad the record to the 8-byte slot (`layout.GearRefPod._pad2`)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          }
+        ]
       }
     },
     {
@@ -32983,6 +54621,50 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "initFactionOwnershipArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "controllingFaction",
+            "docs": [
+              "Dynamic controller to seed (0 = legacy-owned but now in the dynamic regime / contestable)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "contestedUntil",
+            "docs": [
+              "No re-flip until this ts (0 = immediately capturable); must be 0 or strictly-future + capped."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "capturedSeqId",
+            "docs": [
+              "Generation witness (== `StarSystem.seq_id` for a starbase); 0 for Fleet/Region."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "intermediateData",
       "type": {
         "kind": "structTypeNode",
@@ -33087,6 +54769,59 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "liveOffer",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "cargoId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "cargoId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "sideFlags",
+            "docs": [
+              "Same bitmask as `PoolOfferEntry::side_flags` (`SIDE_SELL` / `SIDE_BUY`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "price",
+            "docs": [
+              "Concrete price drawn within the envelope band at reveal (Atlas/Floyds per unit)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "remainingQty",
+            "docs": [
+              "Remaining quantity; decremented per fill, capped by treasury stock + player cargo at trade time."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "locationTag",
       "type": {
         "kind": "tupleTypeNode",
@@ -33132,6 +54867,18 @@
           },
           {
             "kind": "structFieldTypeNode",
+            "name": "rewardReclaimAt",
+            "docs": [
+              "`0` for ordinary carried cargo. Reward items stay owner-locked until this reclaim timestamp."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
             "name": "loot",
             "docs": [
               "the loot"
@@ -33142,6 +54889,38 @@
             }
           }
         ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "loyaltyEpochStatus",
+      "docs": [
+        "Lifecycle of one faction loyalty epoch."
+      ],
+      "type": {
+        "kind": "enumTypeNode",
+        "variants": [
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "open",
+            "discriminator": 0
+          },
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "closed",
+            "discriminator": 1
+          },
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "swept",
+            "discriminator": 2
+          }
+        ],
+        "size": {
+          "kind": "numberTypeNode",
+          "format": "u8",
+          "endian": "le"
+        }
       }
     },
     {
@@ -33597,6 +55376,47 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "medallionRewardConfig",
+      "docs": [
+        "A medallion generation and the buyer liability attached to it.",
+        "",
+        "Changing `cargo_id` creates a new token generation. Keeping `cargo_id` while changing `buyer_price`",
+        "reprices every outstanding token and therefore requires an explicit update opt-in."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "cargoId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "cargoId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "generation",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "buyerPrice",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "minMax",
       "docs": [
         "A min/max struct storing the min and max modifiers for a recipe.",
@@ -33675,6 +55495,20 @@
                 }
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "minorFactionId",
+      "type": {
+        "kind": "tupleTypeNode",
+        "items": [
+          {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
           }
         ]
       }
@@ -33802,6 +55636,18 @@
             "name": "lpValue",
             "docs": [
               "the LP value of the ship"
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "medallionValue",
+            "docs": [
+              "the medallion accounting value of the ship"
             ],
             "type": {
               "kind": "numberTypeNode",
@@ -34367,6 +56213,238 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "perkDefInput",
+      "docs": [
+        "One perk-catalogue row, authored on-chain (the on-chain mirror of the reference",
+        "`PerkDef`, perks_rs:80-99). `BorshSerialize/Deserialize + TypeToIdl` for the client/IDL",
+        "surface (as `CrewTransferInput`, crew_transfer_common_rs:129)."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "id",
+            "docs": [
+              "stable catalogue id (`PerkSlot.perk_id`; `0` reserved = empty)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "slotFamily",
+            "docs": [
+              "the no-op-default slot family this perk's delta lands on (raw `SlotFamily` byte)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "trigger",
+            "docs": [
+              "the trigger gating the perk (raw `Trigger` byte)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "magPerTier",
+            "docs": [
+              "magnitude per tier, as the `i16` q-format the summary stores (master §5.1 fixed-point)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "aptitudeGate",
+            "docs": [
+              "the aptitude whose major/anomalous tag gates the offer (raw `Aptitude` byte)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rarityFloor",
+            "docs": [
+              "the rarity floor (raw `Rarity` byte)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "personalityTraitIdx",
+            "docs": [
+              "optional personality gate: `trait_idx`/`op`/`threshold_q8` (`op == 0xFF` ⇒ none)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "personalityOp",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "personalityThresholdQ8",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "perkSlot",
+      "docs": [
+        "One unlocked perk slot (master §3.1: `[PerkSlot; 4]`). `perk_id == 0` ⇒ empty",
+        "(sentinel, same rationale as `GearRef`; reference-impl `PerkSlot`, record_rs:304-315).",
+        "",
+        "Byte-exact to `layout.PerkSlotPod` (record_rs:508-516):",
+        "`perk_id(2) + tier(1) + _pad(1) = 4 B`."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "perkId",
+            "docs": [
+              "On-chain perk definition id. `0` ⇒ empty slot (the sentinel)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "tier",
+            "docs": [
+              "Perk tier."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad",
+            "docs": [
+              "Padding to the 4-byte slot (`layout.PerkSlotPod._pad`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "pilotXpBudget",
+      "docs": [
+        "Regenerating pilot XP budget (AP-style). Pilot XP from movement draws from",
+        "this budget, which refills continuously in real time — independent of any",
+        "player action, so a lapsed player loses nothing and a scripted fleet cannot",
+        "out-earn the regen rate no matter how many actions it performs.",
+        "",
+        "The final eight bytes preserve the legacy `available: u64` wire slot as",
+        "`available: u16` followed by a Q0.48 fractional carry. Legacy values were",
+        "bounded to 360, so existing account bytes decode directly with a zero carry."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastAccrualTime",
+            "docs": [
+              "Timestamp regen has been accounted up to. Remainder seconds toward the",
+              "next XP stay unconsumed, so frequent small accruals lose nothing."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "available",
+            "docs": [
+              "Whole Pilot XP currently available to earn."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "fractionalCarry",
+            "docs": [
+              "Fractional Pilot XP accumulated across movement settlements, encoded as",
+              "an unsigned Q0.48 little-endian value."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 6
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "planet",
       "type": {
         "kind": "structTypeNode",
@@ -34586,6 +56664,114 @@
                   }
                 }
               ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "poolOfferEntry",
+      "docs": [
+        "A single registered offer in a pool's envelope: one item the NPC may sell and/or buy.",
+        "",
+        "`side_flags` is a bitmask (not an [`OrderSide`](crate::state::OrderSide) enum) so the entry stays",
+        "`Pod`/zero-copy, exactly like `ScanLootEntry`: `bit0` = NPC sells to the player (Ask),",
+        "`bit1` = NPC buys from the player (Bid — the faucet leg, gated by `EncounterPool::faucet_enabled`)."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "cargoId",
+            "docs": [
+              "The item this offer concerns (same id space as the cargo/market system)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "cargoId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "sideFlags",
+            "docs": [
+              "Side bitmask: `SIDE_SELL` (NPC sells / Ask) and/or `SIDE_BUY` (NPC buys / Bid / faucet)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minPrice",
+            "docs": [
+              "Predefined price band, Atlas (Floyds). The concrete price is drawn in `[min, max]` at reveal.",
+              "A truly fixed price is the degenerate band `min == max`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "maxPrice",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "minQty",
+            "docs": [
+              "Per-spawn supply band (units). The concrete qty is drawn in `[min, max]`, then capped by the",
+              "treasury reserve and (at trade time) by the player's own fleet cargo."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "maxQty",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "threshold",
+            "docs": [
+              "Threshold gate over the reveal draw value (same semantics as `ScanLootEntry.threshold`):",
+              "the offer is eligible only when `threshold < value`. Enables \"rare within the rare event\" items."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rollWeight",
+            "docs": [
+              "Selection weight for the weighted draw (same domain as `ScanLootEntry.roll_weight`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
             }
           }
         ]
@@ -34830,7 +57016,7 @@
             "kind": "structFieldTypeNode",
             "name": "safetyStatus",
             "docs": [
-              "The safety status of this region"
+              "Whether this region currently resolves to an effective low-risk zone."
             ],
             "type": {
               "kind": "definedTypeLinkNode",
@@ -34924,7 +57110,7 @@
             "kind": "structFieldTypeNode",
             "name": "connections",
             "docs": [
-              "the connections of this region"
+              "Configured logical connections (separate from geometric border adjacency)."
             ],
             "type": {
               "kind": "arrayTypeNode",
@@ -35096,6 +57282,115 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "registerEncounterPoolArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "triggerWeight",
+            "docs": [
+              "Ultra-rare candidacy chance numerator; the probability is `trigger_weight / trigger_total`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "triggerTotal",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "marketTtlSecs",
+            "docs": [
+              "Market lifetime once revealed, in seconds (e.g. 300)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "atlasBurnBps",
+            "docs": [
+              "ATLAS-burn sink on the faucet leg, in basis points (`0` = off until econ enables)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "faucetEnabled",
+            "docs": [
+              "`0` = faucet (NPC buys from the player) disabled ⇒ the market is sell-only."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rotationEnabled",
+            "docs": [
+              "`0` = no catalog rotation."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rotationPeriodSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "offers",
+            "docs": [
+              "The allowed offer set (buy/sell per `side_flags`). Must be non-empty."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "poolOfferEntry"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "registerStarbaseArgs",
       "docs": [
         "Struct for data input to Register `Starbase`"
@@ -35196,6 +57491,128 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "relationEntry",
+      "docs": [
+        "Per-pair relation record (the `Map` value). Account-field-only → `borsh_with_bytemuck!`. CANNOT be `Pod`",
+        "(it embeds the [`Relationship`] enum). `#[repr(C)]` with `PackedValue` for the i64 keeps it align-1",
+        "without `packed` (mirrors [`ScanLootEntry`](crate::state::ScanLootEntry))."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rel",
+            "docs": [
+              "The relationship kind."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "relationship"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "docs": [
+              "Reserved per-pair growth (NOT alignment padding)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 7
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "ceasefireUntil",
+            "docs": [
+              "Unix ts the ceasefire lifts; attackable once `now >= this` (meaningful only when `rel == Ceasefire`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "relationship",
+      "docs": [
+        "Pairwise faction relationship. Dual-use (the value stored in [`RelationEntry`] AND the `rel` arg of",
+        "`SetFactionRelation`) → mirror [`FactionStatus`](crate::state::FactionStatus): explicit Borsh",
+        "(variant-aware, for the ix arg + IDL) + bytemuck (for the packed account field). NOT `borsh_with_bytemuck!`."
+      ],
+      "type": {
+        "kind": "enumTypeNode",
+        "variants": [
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "neutral",
+            "discriminator": 0
+          },
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "allied",
+            "discriminator": 1
+          },
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "hostile",
+            "discriminator": 2
+          },
+          {
+            "kind": "enumEmptyVariantTypeNode",
+            "name": "ceasefire",
+            "discriminator": 3
+          }
+        ],
+        "size": {
+          "kind": "numberTypeNode",
+          "format": "u8",
+          "endian": "le"
+        }
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "renownConfig",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "divisor",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "feederCategories",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "researchNode",
       "type": {
         "kind": "structTypeNode",
@@ -35222,6 +57639,30 @@
             "type": {
               "kind": "numberTypeNode",
               "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "maxLevel",
+            "docs": [
+              "Maximum unlock level. A value of 1 is a normal one-time node; 0 means unlimited."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "costGrowthBps",
+            "docs": [
+              "Linear per-level economic cost increase in basis points, applied to cargo and ATLAS costs."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
               "endian": "le"
             }
           },
@@ -35774,9 +58215,376 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "rosterSummary",
+      "docs": [
+        "The cached O(1) roster aggregate — **315-byte** packed header (the original 274-byte block",
+        "plus the tail-appended per-category-XP accumulators and `max_rarity` cache).",
+        "",
+        "Field order and sizes are byte-exact to `crew-mechanics-detail.md` §1.3 /",
+        "reference-impl `layout.RosterSummaryPod` (record_rs:582-608). Blocks:",
+        "identity/paging/census = 40, aptitude sums = 88, perks = 92, gear/command = 30,",
+        "xp = 16, reserved = 8 → 274 (the original block; the appended tails bring the struct",
+        "to 315 — `consts_rs.ROSTER_SUMMARY_BYTES`)."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "version",
+            "docs": [
+              "Account/page data version — doubles as the **page-level schema version** for the",
+              "cross-chain bridge (cuniculture review, PR #732): it versions the roster-account",
+              "envelope, while the per-crew snapshot that exits escrow independently is versioned by",
+              "`super.CrewRecord.schema_version`. Bumped only on an envelope-shape change; the canonical",
+              "round-trip encoding is specified in the crew bridge design doc."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pageIndex",
+            "docs": [
+              "This page's index within a multi-page roster (`0`-based)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pageCount",
+            "docs": [
+              "Total page count for this roster."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "pad0",
+            "docs": [
+              "Pad to align the census block (`layout.RosterSummaryPod._pad0`)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 3
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "countByAssignment",
+            "docs": [
+              "Census: count of crew per `CrewStatusTag` (`u32` each), indexed by the tag",
+              "discriminant. Width = `CrewStatusTag::COUNT == 5`."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u32",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 5
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rentedCount",
+            "docs": [
+              "Number of rented crew on this roster."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "normalizedCrewTotal",
+            "docs": [
+              "The resurrected `total_crew` — count of present crew (AtStarbase/OnFleet/Busy)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "recordCount",
+            "docs": [
+              "Total records on this page (present + absent)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "sumApt",
+            "docs": [
+              "Σ aptitude magnitude across present crew, per aptitude (`u64` each, indexed by",
+              "`Aptitude`). Width = `Aptitude.COUNT == 9`."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 9
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "sumWeights",
+            "docs": [
+              "Σ per-crew weights (level/rarity-weighted denominator for averages)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "rarityWeightSum",
+            "docs": [
+              "Σ rarity weight (the anti-P2W rarity-counted-once denominator, master §5.2)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "perkUncond",
+            "docs": [
+              "Pre-summed `Always`-trigger perk deltas per slot-family, as `i16` q-format",
+              "(indexed by `SlotFamily`, width `SlotFamily.COUNT == 13`). The fold applies the",
+              "joint clamp; this is the raw running sum."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "i16",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 13
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "perkCond",
+            "docs": [
+              "Conditional perks the consumer evaluates per-tick (≤ `PERK_COND_CAP == 8`);",
+              "unused slots have `perk_id == 0`."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "condPerkEntry"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 8
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "nonneutralSlotMask",
+            "docs": [
+              "Bit `i` set ⇒ the fleet is non-neutral on `SlotFamily(i)` — the breadth-cap mask",
+              "(master §5.1; the cross-loop product bound is enforced at the fold via",
+              "`MAX_NONNEUTRAL_SLOTS_PER_FLEET`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "gearScalar",
+            "docs": [
+              "Pre-summed gear deltas per slot-family, `i16` q-format (indexed by `SlotFamily`)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "i16",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 13
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "commandConcurrency",
+            "docs": [
+              "Command-officer concurrency bonus, `i16` (extra parallel jobs; master §3.5)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "commandCrewcount",
+            "docs": [
+              "Command crew-count COST reduction, `i16` q-format (≤ 1.0, floor",
+              "`CREWCOUNT_FLOOR = 0.87` at the fold — contract-change request #4, never `×1.15`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "xpAccumulator",
+            "docs": [
+              "Fleet per-capita XP accumulator (the lazy-XP high-water mark; master §S.4)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lastXpTick",
+            "docs": [
+              "Unix ts of the last XP tick applied to `xp_accumulator`."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reserved",
+            "docs": [
+              "Forward-compat reserved tail (`layout.RosterSummaryPod._reserved`). Zero today;",
+              "lets the header grow without a migration (kept inside the original 274-byte budget). The",
+              "per-skill-XP accumulator below is appended AFTER this, so offsets ≤ 273 stay byte-identical."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 8
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "xpAccumulatorByCategory",
+            "docs": [
+              "Per-activity per-capita XP accumulator (the §S.4 lazy-XP high-water mark, ONE stream per",
+              "`CrewXpCategory`(crate.state.CrewXpCategory)). The single-track `xp_accumulator` above",
+              "(off 250) is kept as the lifetime-total high-water mark for back-compat; these are the",
+              "per-activity high-water marks each crew's `xp_realized_by_category` snapshots against. A",
+              "gameplay loop pours its activity's XP into `xp_accumulator_by_category[cat]` in O(1)",
+              "(`crate.folds.xp.pour_xp_category`); crew realize their per-category share lazily on",
+              "touch (load/unload/`LevelUpCrew`)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 5
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "maxRarity",
+            "docs": [
+              "Highest `Rarity`(crate.state.Rarity) discriminant among the crew this summary",
+              "aggregates (`0` = Common/empty … `5` = Anomaly) — the faithful per-fleet rarity context",
+              "for the `RarityAtLeast` trigger (Veteran's Pull #18: fires while a `>= Legendary` crew is",
+              "onboarded). Maintained by the same from-scratch re-derive that owns the modifier lanes",
+              "(`load_fleet_rs.rederive_fleet_modifier_lanes` — reset to 0, then `max(rec.rarity)` over",
+              "the onboarded subset). Zero-default ⇒ `Common` ⇒ `RarityAtLeast` false ⇒ flag-off-safe.",
+              "Tail-appended (the #17 technique): every offset ≤ 313 stays byte-identical."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "safetyStatus",
       "docs": [
-        "The safety status of a region"
+        "Whether a region's authored risk tier is currently secured by faction control.",
+        "",
+        "`Safe` is the dynamic signal used to promote a non-home region to an effective",
+        "low-risk zone. `Border` leaves the region at its authored risk tier."
       ],
       "type": {
         "kind": "enumTypeNode",
@@ -35797,6 +58605,44 @@
           "format": "u8",
           "endian": "le"
         }
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "salvageRewardEntry",
+      "docs": [
+        "One entry in the synthetic-salvage table."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "cargoId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "cargoId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "weight",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "referenceValue",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
       }
     },
     {
@@ -35894,6 +58740,36 @@
               "kind": "numberTypeNode",
               "format": "u32",
               "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "researchRequirementCount",
+            "docs": [
+              "Number of populated entries in research_requirements."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "researchRequirements",
+            "docs": [
+              "All listed research tags must be present for this loot entry to roll."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "researchTag"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 4
+              }
             }
           }
         ]
@@ -36137,6 +59013,342 @@
           "format": "u8",
           "endian": "le"
         }
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "setContestedArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "contestedUntil",
+            "docs": [
+              "New contested window (0 = clear; else strictly-future + capped)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "setFactionConfigArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "decayPerDay",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "dailyCap",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standingBps",
+            "docs": [
+              "Ask-leg value→standing bps (`0` disables sell-order accrual)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "drHalfLife",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "drScale",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standingEpochCap",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "standingEpochLenSecs",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "dockMinBand",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "territoryYieldPerTick",
+            "docs": [
+              "P5 territory payoff: ATLAS yield per hold-tick to the controlling faction's treasury (0 = disabled)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "territoryYieldTickSecs",
+            "docs": [
+              "P5 territory payoff: yield accrual cadence (secs)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "setFactionRelationConfigArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "combatGatingEnabled",
+            "docs": [
+              "`0` = OFF (today's same-faction-only combat), `1` = relation-gated combat ON."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "territoryAccessEnabled",
+            "docs": [
+              "`0` = OFF (own-faction docking only), `1` = relation/standing dock admission ON."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "crossFactionEconomicsEnabled",
+            "docs": [
+              "P3.5 reserved: cross-faction warp economics master switch (keep `0`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "ceasefireMinDurationSecs",
+            "docs": [
+              "Minimum ceasefire duration (secs) `SetFactionRelation` will accept."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "reCeasefireCooldownSecs",
+            "docs": [
+              "Cooldown (secs) after a ceasefire ends before the same pair may re-enter one."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "alliedTollBps",
+            "docs": [
+              "P3.5 reserved: allied cross-faction warp toll (bps)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "neutralTollBps",
+            "docs": [
+              "P3.5 reserved: neutral cross-faction warp toll (bps)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "dynamicCaptureEnabled",
+            "docs": [
+              "P4 territory: dynamic-capture regime master switch (`0` = OFF, `1` = ON)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "contestedWindowSecs",
+            "docs": [
+              "P4 territory: base contested-window (secs) a capture stamps onto the sidecar (clamped UP to",
+              "`MIN_CONTESTED_WINDOW_SECS`); `0` ⇒ only the floor applies."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "nemesisActive",
+            "docs": [
+              "P5b antagonist master switch (`0` = OFF, `1` = ON). The activation double-gate is",
+              "`dynamic_capture_enabled == 1 && nemesis_active == 1`. Keep `0` until the §10 activation checklist passes."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "setFleetDirectiveArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "kind",
+            "docs": [
+              "Directive kind discriminant ([`FleetDirectiveKind`]); unknown ⇒ `InvalidFleetDirective`.",
+              "`NemesisHunt` (=4) is ADMIN-ONLY."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "aggression",
+            "docs": [
+              "0–100 off-chain AI dial (pursuit range / engage odds). NO on-chain rate consequence."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "targetFaction",
+            "docs": [
+              "Target faction for `Invade`/`Defend`/etc. (0 = none)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "target",
+            "docs": [
+              "Target coordinate (`[Point; 2]`)."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "numberTypeNode",
+                "format": "i64",
+                "endian": "le"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "expiresAt",
+            "docs": [
+              "Absolute unix expiry (0 = never; encoded i32-relative on write — out-of-range ⇒ `InvalidFleetDirective`)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          }
+        ]
       }
     },
     {
@@ -36940,6 +60152,20 @@
           "format": "u8",
           "endian": "le"
         }
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "stackRule",
+      "type": {
+        "kind": "tupleTypeNode",
+        "items": [
+          {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        ]
       }
     },
     {
@@ -37819,6 +61045,123 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "stimEffect",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stat",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "combatStatField"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "deltaBps",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "charges",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "stackRule",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "stackRule"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "stimulantDefinition",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "effectCount",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "effects",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "stimEffect"
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 3
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "stimulantDefinitions",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "seqId",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "definitions",
+            "type": {
+              "kind": "mapTypeNode",
+              "key": {
+                "kind": "definedTypeLinkNode",
+                "name": "cargoId"
+              },
+              "value": {
+                "kind": "definedTypeLinkNode",
+                "name": "stimulantDefinition"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u32",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "structureInstanceState",
       "type": {
         "kind": "enumTypeNode",
@@ -37933,6 +61276,38 @@
           "format": "u8",
           "endian": "le"
         }
+      }
+    },
+    {
+      "kind": "definedTypeNode",
+      "name": "transferFactionOwnershipArgs",
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "newController",
+            "docs": [
+              "New dynamic controller (0 = hand back to legacy/contestable)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "minorFactionId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "contestedUntil",
+            "docs": [
+              "New contested window (0 = immediately capturable)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "i64",
+              "endian": "le"
+            }
+          }
+        ]
       }
     },
     {
@@ -38704,6 +62079,24 @@
           },
           {
             "kind": "structFieldTypeNode",
+            "name": "maxLevel",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "costGrowthBps",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
             "name": "cargoCost",
             "type": {
               "kind": "mapTypeNode",
@@ -39300,6 +62693,35 @@
     },
     {
       "kind": "definedTypeNode",
+      "name": "upgradeLpRate",
+      "docs": [
+        "One starbase-upgrade material's LP rate."
+      ],
+      "type": {
+        "kind": "structTypeNode",
+        "fields": [
+          {
+            "kind": "structFieldTypeNode",
+            "name": "cargoId",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "cargoId"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "lpPerRawUnit",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "definedTypeNode",
       "name": "upgradeResource",
       "type": {
         "kind": "structTypeNode",
@@ -39538,6 +62960,14 @@
           },
           {
             "kind": "structFieldTypeNode",
+            "name": "renownConfig",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "renownConfig"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
             "name": "levelThresholds",
             "type": {
               "kind": "arrayTypeNode",
@@ -39638,6 +63068,18 @@
             "type": {
               "kind": "definedTypeLinkNode",
               "name": "categoryXpInfo"
+            }
+          },
+          {
+            "kind": "structFieldTypeNode",
+            "name": "councilRankLevelCarry",
+            "docs": [
+              "Career levels gained toward the next Council Rank renown point."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
             }
           }
         ]
@@ -39752,6 +63194,264 @@
     },
     {
       "kind": "pdaNode",
+      "name": "atlasRewardConfig",
+      "docs": [
+        "One immutable, fully authored reward configuration version."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "41746c6173526577617264436f6e666967",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "configVersion",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u32",
+            "endian": "le"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "atlasRewardRegistry",
+      "docs": [
+        "Per-game epoch clock and pointer to immutable reward-config versions."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "41746c61735265776172645265676973747279",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "atlasRewardTreasury",
+      "docs": [
+        "Game-level finite cargo reserve backing medallion and synthetic-salvage issuance."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "41746c61735265776172645472656173757279",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "kingSystemTracker",
+      "docs": [
+        "Canonical membership and current effective major-faction ownership for the 69 King systems."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "4b696e6753797374656d547261636b6572",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "loyaltyAtlasBank",
+      "docs": [
+        "Persistent accumulated ATLAS entitlement for one `(profile, faction)`.",
+        "",
+        "Expiry is inactivity-based: a new credit extends the whole accumulated balance. Configuring expiry to",
+        "`0` makes the bank non-expiring. This is bounded state (one account per profile/faction), supports",
+        "week/month batching, and avoids an unbounded list of daily claim tranches."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "4c6f79616c747941746c617342616e6b",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "profile",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "loyaltyContribution",
+      "docs": [
+        "One profile's LP in one faction epoch. LP never rolls forward."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "4c6f79616c7479436f6e747269627574696f6e",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "profile",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "epochIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "loyaltyEpoch",
+      "docs": [
+        "One faction's daily LP total and reserved ATLAS pool."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "4c6f79616c747945706f6368",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "epochIndex",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
       "name": "celestialBody",
       "docs": [
         "CelestialBody",
@@ -39857,6 +63557,93 @@
     },
     {
       "kind": "pdaNode",
+      "name": "fleetCrewBinding",
+      "docs": [
+        "Each fleet's per-fleet crew aggregate. **Presence = at least one crew onboarded.** The",
+        "gameplay folds read `summary` (the sum of ONLY this fleet's onboarded crew), maintained by",
+        "`LoadFleetCrewRoster`/`UnloadFleetCrewRoster`.",
+        "",
+        "Body = 1 (version) + 1 (bump) + 6 (reserved) + 32 (fleet) + 32 (owner) + 315 (summary)",
+        "+ 8 (last_action_epoch) = **395 B**, align 1. (The summary grew 274 → 314 with the",
+        "per-skill-XP accumulator block, → 315 with the `max_rarity` cache byte; `last_action_epoch`",
+        "is the binding-tail Cold Start marker. The header fields before the summary —",
+        "version/bump/_reserved/fleet/owner, 72 B — are unchanged, so the summary still begins at",
+        "account-offset `8 (disc) + 72 = 80`, exactly as before.)"
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "466c6565744372657742696e64696e67",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "fleet",
+          "docs": [
+            "The owning `Fleet`."
+          ],
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "crewRoster",
+      "docs": [
+        "The bulk crew container for one `(Character, page_index)`: a `RosterSummary` cache",
+        "header + an append-only `List<CrewRecord>`.",
+        "",
+        "`#[unsized_type(program_account, seeds = CrewRosterSeeds)]` — same form as the",
+        "marketplace `Market` (marketplace/src/state_rs:384-398) and SAGE `Character`",
+        "(character_rs:17-29). `summary` is the sized packed header (315 B); `crew` is the",
+        "unsized tail."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "43726577526f73746572",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "character",
+          "docs": [
+            "The owning SAGE `Character`."
+          ],
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "pageIndex",
+          "docs": [
+            "`0`-based page index within this character's roster."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u16",
+            "endian": "le"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
       "name": "currencyConfigCache",
       "seeds": [
         {
@@ -39875,6 +63662,516 @@
           "name": "gameId",
           "type": {
             "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "encounterCommit",
+      "docs": [
+        "Per-character commit tracker for the two-phase encounter reveal (Option B — migration-safe; this",
+        "avoids touching the core `Fleet` account, which is a non-singleton `#[unsized_type]` with no spare",
+        "pad). Created once per character via `OpenEncounterTracking`; a scan that arms an encounter stamps",
+        "`commit_slot` + `region_id` + the triggering `fleet` here. The reveal reads it, draws the contents",
+        "from a *later* slot's hash, and clears it. One pending encounter per character at a time — a",
+        "subsequent scan overwrites the prior pending commit (reinforces the anti-multi-fleet design)."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "456e636f756e746572436f6d6d6974",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "character",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "encounterPool",
+      "docs": [
+        "The dev-registered ENVELOPE for one `(region, minor_faction)` encounter pool.",
+        "",
+        "Long-lived; created/edited only by `MANAGE_NPC_ENCOUNTERS`-gated admin instructions and read-only",
+        "at encounter time. Modeled on [`ScanPattern`](crate::state::ScanPattern): a sized header + an",
+        "`#[unsized_start]` `List` tail (additive growth lives in the tail)."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "456e636f756e746572506f6f6c",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "regionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "regionId"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "minorFaction",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "encounterTreasury",
+      "docs": [
+        "The finite, pre-funded reserve + per-epoch ATLAS-out circuit-breaker for one `(region, faction)` pool.",
+        "",
+        "All economic value lives here (decisions #1/#3): the ATLAS `vault` pays sell-backs and receives",
+        "player buys; `reserves` is the finite cargo stock (no minting — Asks draw down, Bids credit back).",
+        "Kept separate from [`EncounterPool`] (config) so the value account is written on trades while the",
+        "envelope stays a rarely-written config account. Modeled on `LocalMarket`'s vault + `CargoPod`'s map."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "456e636f756e7465725472656173757279",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "regionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "regionId"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "minorFaction",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "ephemeralMarket",
+      "docs": [
+        "The revealed, player-scoped, time-boxed NPC market (Phase 3). Created (player-funded) at reveal when",
+        "the rare candidacy hits; holds the concrete `LiveOffer`s + an `expires_at`. Trades settle DIRECTLY",
+        "against the `EncounterTreasury`, so this account itself holds NO funds (close is trivial — nothing to",
+        "sweep). One open market per character at a time (seeds = game + owner character); the prior one must",
+        "be reaped before a new reveal."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "457068656d6572616c4d61726b6574",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "ownerCharacter",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "factionAccount",
+      "docs": [
+        "The per-faction record in the dynamic registry (decision D1/D8). Sized, packed, 209 bytes.",
+        "",
+        "Modeled on `ProfileFactionAccount` (a sized",
+        "`ProgramAccount` embedding the [`Faction`] enum) + the [`EncounterPool`](crate::state::EncounterPool)",
+        "header (`(game, …, minor_faction)` scoping). Growth is by carving from `_reserved` (version-gated),",
+        "never by appending."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "46616374696f6e4163636f756e74",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "factionConfig",
+      "docs": [
+        "Per-game reputation dials. Sized, packed, 48 bytes."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "46616374696f6e436f6e666967",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "factionEconomicsConfig",
+      "docs": [
+        "Per-game NPC-economy tuning dials. Sized, packed, `Align1`, 72 bytes."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "46616374696f6e45636f6e6f6d696373436f6e666967",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "factionEpochMeter",
+      "docs": [
+        "Per-`(game, faction_id)` aggregate standing-emission meter. Sized, packed, 56 bytes."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "46616374696f6e45706f63684d65746572",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "factionMarket",
+      "docs": [
+        "A persistent faction market at one starbase. 120 B sized header + `offers: List<LiveOffer>` tail."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "46616374696f6e4d61726b6574",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "system",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "starbaseSeqId",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u64",
+            "endian": "le"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "factionOwnership",
+      "docs": [
+        "Dynamic-ownership sidecar for ONE asset. Sized `Pod` (the `CurrencyConfigCache` idiom), `#[repr(C,packed)]`,",
+        "`Align1`. `directive_block` is RESERVED for P5 (zero-written, read nowhere in P4)."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "46616374696f6e4f776e657273686970",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "assetKind",
+          "docs": [
+            "1-byte mandatory discriminator — the cross-kind collision boundary; never drop, never derive from data."
+          ],
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "assetKey",
+          "docs": [
+            "32-byte canonical identity."
+          ],
+          "type": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 32
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "factionRelationTracker",
+      "docs": [
+        "The diplomacy relation matrix + combat-gating config for one game.",
+        "",
+        "Sized 66-B header + a sparse `Map<FactionPair, RelationEntry>` tail. `combat_gating_enabled == 0`",
+        "(default) reproduces today's behavior. Future fields carve from `_reserved` (BEFORE `#[unsized_start]`)."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "46616374696f6e52656c6174696f6e73",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "factionStanding",
+      "docs": [
+        "Per-`(game, profile, faction_id)` reputation standing (P1). Sized, packed, 132 bytes."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "46616374696f6e5374616e64696e67",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "profile",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "factionTreasury",
+      "docs": [
+        "Per-faction value account (one per faction). 76 B sized header + `reserves` + `floors` Map tails."
+      ],
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "46616374696f6e5472656173757279",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "factionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "minorFactionId"
           }
         }
       ]
@@ -40020,6 +64317,130 @@
             "kind": "numberTypeNode",
             "format": "u64",
             "endian": "le"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "missionStakeVault",
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "4d697373696f6e5661756c74",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "mission",
+          "docs": [
+            "The `MissionProcess` key — one vault per mission run."
+          ],
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "missionTreasury",
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "4d697373696f6e5472656173757279",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "regionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "regionId"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "outlawFlag",
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "6f75746c61775f666c6167",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "profile",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "faction",
+          "type": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "pdaNode",
+      "name": "regionOrderAnchor",
+      "seeds": [
+        {
+          "kind": "constantPdaSeedNode",
+          "type": {
+            "kind": "bytesTypeNode"
+          },
+          "value": {
+            "kind": "bytesValueNode",
+            "data": "526567696f6e4f72646572416e63686f72",
+            "encoding": "base16"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "gameId",
+          "type": {
+            "kind": "publicKeyTypeNode"
+          }
+        },
+        {
+          "kind": "variablePdaSeedNode",
+          "name": "regionId",
+          "type": {
+            "kind": "definedTypeLinkNode",
+            "name": "regionId"
           }
         }
       ]
@@ -40651,6 +65072,444 @@
       "message": "Fleet is rented",
       "docs": [
         "Fleet is rented"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "rosterPageMismatch",
+      "code": 1367932975,
+      "message": "Crew roster page mismatch",
+      "docs": [
+        "Crew roster page index does not match the instruction's page_index"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "crewAssetMismatch",
+      "code": 1367932976,
+      "message": "Crew asset mismatch",
+      "docs": [
+        "A supplied crew asset id was not found on the roster page"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "crewFeatureDisabled",
+      "code": 1367932977,
+      "message": "Crew feature disabled",
+      "docs": [
+        "Crew feature is disabled (Game.crew_config is None)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "crewRecordNotFound",
+      "code": 1367932978,
+      "message": "Crew record not found",
+      "docs": [
+        "Crew record not found on the roster page"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "crewBadStatus",
+      "code": 1367932979,
+      "message": "Crew bad status",
+      "docs": [
+        "Crew is in the wrong status for this action"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "crewBusy",
+      "code": 1367932980,
+      "message": "Crew busy",
+      "docs": [
+        "Crew is busy (reserved by a quest / garrison)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "perkOfferGate",
+      "code": 1367932981,
+      "message": "Perk offer gate",
+      "docs": [
+        "Perk offer-gate not satisfied (rarity/aptitude/personality)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "gearSlotOccupied",
+      "code": 1367932982,
+      "message": "Gear slot occupied",
+      "docs": [
+        "Target gear slot is already occupied"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "crewAlreadyBound",
+      "code": 1367932983,
+      "message": "Crew already bound",
+      "docs": [
+        "Crew asset id already has a record on this roster page (duplicate bind/migrate rejected;",
+        "PR #732 review — the double-bind guard)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "crewXpAwardTooLarge",
+      "code": 1367932984,
+      "message": "Crew XP award too large",
+      "docs": [
+        "AwardCrewActivityXp per-category award exceeds the per-call cap (PR #732 review)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "setPerkDefinitionsUnsupported",
+      "code": 1367932985,
+      "message": "Set perk definitions unsupported",
+      "docs": [
+        "SetPerkDefinitions was called but the runtime perk-definition map is not yet wired",
+        "(the folds read the static catalogue). Explicit failure beats silently accepting and",
+        "discarding the supplied definitions (PR #732 second review)."
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "crewRosterOwnerMismatch",
+      "code": 1367932986,
+      "message": "Crew roster owner mismatch",
+      "docs": [
+        "The supplied CrewRoster is not the expected (character, page_index) PDA — a caller",
+        "tried to operate on a roster page that does not belong to the validated character",
+        "(PR #732 second review — the roster owner binding)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "crewAuthorityMismatch",
+      "code": 1367932987,
+      "message": "Crew authority mismatch",
+      "docs": [
+        "The crew attestation authority did not sign / does not match `Game.crew_config`",
+        "(PR #732 second review — Bind/Migrate are authority-gated until Phase-2 attestation)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "fleetCrewPageConflict",
+      "code": 1367932988,
+      "message": "Fleet crew page conflict",
+      "docs": [
+        "The FleetCrewBinding is pinned to a different roster page (one-page-per-fleet",
+        "invariant — PR #732 second review)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionDrainBlocked",
+      "code": 1367932989,
+      "message": "Faction drain blocked: own-faction opposition requires an outlaw declaration",
+      "docs": [
+        "A mission's settled action would DRAIN the rightful incumbent of a sector the actor's OWN",
+        "faction holds, and the actor is not a declared outlaw — the own-faction anti-grief gate",
+        "(doc 180 §3 Phase-2 faction-stance). Declare outlaw to act against your own faction."
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "commitmentWindowActive",
+      "code": 1367932990,
+      "message": "Outlaw commitment window still active",
+      "docs": [
+        "ClearOutlaw was attempted while the 2-epoch commitment window is still active — the outlaw",
+        "flag is locked until `now >= pvp_until` (doc 180 §3d, the PvP-flag commitment)."
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "reservedFactionId",
+      "code": 1367932991,
+      "message": "Reserved faction id",
+      "docs": [
+        "Reserved faction id (0 = null; 1/2/3 = majors, seed-only)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "invalidFactionFlags",
+      "code": 1367932992,
+      "message": "Invalid faction flags",
+      "docs": [
+        "Capability flags contain unknown bits"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionFlagNotPermitted",
+      "code": 1367932993,
+      "message": "Faction flag not permitted",
+      "docs": [
+        "Caller may not grant the requested high-trust flags"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "invalidFactionStatusTransition",
+      "code": 1367932994,
+      "message": "Invalid faction status transition",
+      "docs": [
+        "Illegal faction status transition"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionBridgeInconsistent",
+      "code": 1367932995,
+      "message": "Faction bridge inconsistent",
+      "docs": [
+        "alignment<->faction_id bridge inconsistent at seed"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "standingProfileMismatch",
+      "code": 1367932996,
+      "message": "Standing profile mismatch",
+      "docs": [
+        "Standing account's profile doesn't match the settling profile"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "standingFactionMismatch",
+      "code": 1367932997,
+      "message": "Standing faction mismatch",
+      "docs": [
+        "Standing account's faction_id doesn't match the credited faction"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "standingPdaMismatch",
+      "code": 1367932998,
+      "message": "Standing PDA mismatch",
+      "docs": [
+        "Standing account PDA doesn't match its derived address"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "standingEpochCapExceeded",
+      "code": 1367932999,
+      "message": "Standing epoch cap exceeded",
+      "docs": [
+        "Per-faction per-epoch standing-emission cap exceeded"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "standingTooLow",
+      "code": 1367933000,
+      "message": "Standing too low",
+      "docs": [
+        "Standing too low for this action"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "standingAccountRequired",
+      "code": 1367933001,
+      "message": "Standing account required",
+      "docs": [
+        "A standing/config/meter account is required for accrual but was not supplied (partial set)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionMarketPdaMismatch",
+      "code": 1367933002,
+      "message": "Faction market PDA mismatch",
+      "docs": [
+        "Faction market PDA doesn't match its derived address"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionMarketTreasuryMismatch",
+      "code": 1367933003,
+      "message": "Faction market treasury mismatch",
+      "docs": [
+        "Faction market's bound treasury doesn't match the supplied treasury"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionReserveFloor",
+      "code": 1367933004,
+      "message": "Faction reserve floor",
+      "docs": [
+        "An Ask would draw a faction treasury reserve below its strategic floor"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionNotActive",
+      "code": 1367933005,
+      "message": "Faction market not active",
+      "docs": [
+        "Faction market is not Active"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionAllied",
+      "code": 1367933006,
+      "message": "Faction is allied",
+      "docs": [
+        "Cannot attack an allied faction (in its homeland)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionCeasefire",
+      "code": 1367933007,
+      "message": "Faction ceasefire active",
+      "docs": [
+        "Cannot attack during an active ceasefire"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionNotCombatant",
+      "code": 1367933008,
+      "message": "Faction is not a combatant",
+      "docs": [
+        "Faction lacks the COMBATANT capability (declared in P3, thrown in P4)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "selfRelation",
+      "code": 1367933009,
+      "message": "Self relation",
+      "docs": [
+        "A faction cannot have a relation with itself"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "invalidFaction",
+      "code": 1367933010,
+      "message": "Invalid faction",
+      "docs": [
+        "Faction account/id is invalid or not Active"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "maxAlliesExceeded",
+      "code": 1367933011,
+      "message": "Max allies exceeded",
+      "docs": [
+        "A faction has reached its maximum simultaneous allies"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "invalidRelationArg",
+      "code": 1367933012,
+      "message": "Invalid relation argument",
+      "docs": [
+        "Invalid relation argument (e.g. ceasefire timestamp in the past)"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "ceasefireTooShort",
+      "code": 1367933013,
+      "message": "Ceasefire too short",
+      "docs": [
+        "Requested ceasefire is shorter than the configured minimum"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "ceasefireCooldown",
+      "code": 1367933014,
+      "message": "Ceasefire cooldown active",
+      "docs": [
+        "Re-entering a ceasefire on this pair is still on cooldown"
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionOwnershipMismatch",
+      "code": 1367933015,
+      "message": "Faction ownership mismatch",
+      "docs": [
+        "P4: the dynamic-ownership sidecar is required-but-absent, stale (wrong generation), or carries an",
+        "unknown asset_kind."
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "starbaseContested",
+      "code": 1367933016,
+      "message": "Starbase contested",
+      "docs": [
+        "P4: the starbase is in its post-capture contested window (`now < contested_until`) and cannot be",
+        "re-flipped yet (anti capture-and-camp); also a too-far-future/over-cap pre-seeded window."
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "invalidFleetDirective",
+      "code": 1367933017,
+      "message": "Invalid fleet directive",
+      "docs": [
+        "P5b: a directive payload is malformed — unknown `FleetDirectiveKind`, or a timestamp that does not",
+        "fit the i32 epoch-relative encoding (`directive_ts_out_of_range`)."
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionDirectiveRateLimited",
+      "code": 1367933018,
+      "message": "Faction directive rate limited",
+      "docs": [
+        "P5b: `SetFleetDirective` was called again before `last_update + DIRECTIVE_COOLDOWN_SECS` elapsed."
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "fleetNotOwnedByFaction",
+      "code": 1367933019,
+      "message": "Fleet not owned by faction",
+      "docs": [
+        "P5b: the supplied fleet's `FactionOwnership(FLEET)` sidecar does not name this faction as controller,",
+        "or the operator profile does not match `FactionAccount.operator_profile`."
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionFleetCapExceeded",
+      "code": 1367933020,
+      "message": "Faction fleet cap exceeded",
+      "docs": [
+        "P5b: `MintNpcFleet` would exceed `FactionAccount.max_npc_fleets` (the primary anti-flood headcount cap)."
+      ]
+    },
+    {
+      "kind": "errorNode",
+      "name": "factionCaptureRateLimited",
+      "code": 1367933021,
+      "message": "Faction capture rate limited",
+      "docs": [
+        "P5b: an NPC faction tried to capture again before its per-faction `last_capture_at +",
+        "faction_capture_cooldown_secs` elapsed (the on-chain anti-blitz brake)."
       ]
     }
   ]


### PR DESCRIPTION
## Description

Refreshes the bundled Player Profile, Profile Faction, Profile Subscription, and SAGE StarFrame/Codama IDLs from `staratlasmeta/programs` `main` at `4d663f28504c3bf90a9c5947a1a2b56140f31b2a`.

All four generated IDLs now report schema version `0.49.0` and retain the expected C4 program IDs. The SAGE registry expands from 144 to 239 instructions, 20 to 48 accounts, and 164 to 207 defined types.

Each baked JSON file is byte-for-byte identical to its source artifact in Programs.

## Type of change

- [x] Other: generated IDL refresh

## Screenshots

Not applicable; there are no visual changes.

## Testing

- Node 20.19: `pnpm test:ci` — 16 files / 106 tests passed
- Node 20.19: `pnpm run lint` — passed with existing warnings only
- Node 20.19: `NEXT_PUBLIC_FLAVOR=zink pnpm run build` — passed
- Verified exact source-file equality for all four IDLs
- Verified every type/count/enum node reachable from the refreshed schemas is supported by the Explorer decoder
- `git diff --check`

## Related Issues

None.

## Checklist

- [x] My code follows the project's style guidelines
- [x] All tests pass locally
- [x] Documentation is unchanged because this is a generated-data refresh
- [x] CI/CD checks pass

## Additional Notes

The generated JSON is intentionally preserved exactly as emitted by Programs rather than reformatted locally.
